### PR TITLE
CEP for the OCI storage of conda packages & repodata

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@ To better allow community members to provide feedback and proposals
 for conda's implementation, all major changes should be submitted as
 **Conda Enhancement Proposals (CEP)**.
 
+## Accepted CEPS:
+
+| CEP | Title |
+| --- | ------- |
+| [1](cep-1.md) | CEP Purpose and Guidelines  |
+| [2](cep-2.md) | Add plugin architecture to conda |
+| [3](cep-3.md) | Using the Mamba solver in conda |
+| [4](cep-4.md) | Implement initial conda plugin mechanism |
+| 5 | Does not exist |
+| [6](cep-6.md) | Add Channel Notices to conda
+| 7 | Does not exist |
+| [8](cep-8.md) | Conda Release Schedule |
+| [9](cep-9.md) | Conda Deprecation Schedule |
+| [10](cep-10.md) | Conda Version Support |
+| [11](cep-11.md) | Define the menuinst standard |
+| [12](cep-12.md) | Serving run_exports metadata in conda channels |
+| [13](cep-13.md) | A new recipe format - part 1 |
+| [14](cep-14.md) | A new recipe format – part 2 - the allowed keys & values |
+| [15](cep-15.md) | Hosting repodata.json and packages separately by adding a base_url property. |
+
 ## References
 
 These proposals are similar to conda-forge's [CFEP](https://github.com/conda-forge/cfep),

--- a/cep-oci.md
+++ b/cep-oci.md
@@ -1,7 +1,7 @@
 <table>
 <tr><td> Title </td><td> OCI registries as conda channels </td>
 <tr><td> Status </td><td> Proposed </td></tr>
-<tr><td> Author(s) </td><td> Wolf Vollprecht &lt;wolf@prefix.dev&gt;</td></tr>
+<tr><td> Author(s) </td><td> Wolf Vollprecht &lt;wolf@prefix.dev&gt;<br> Hind Montassif &lt;hind.montassif@quantstack.net&gt;</td></tr>
 <tr><td> Created </td><td> April 12, 2024</td></tr>
 <tr><td> Updated </td><td> August 7, 2024</td></tr>
 <tr><td> Discussion </td><td> https://github.com/conda/ceps/pull/70 </td></tr>
@@ -48,7 +48,6 @@ Custom mediaTypes defined for the conda channels use case are as follows:
 | repodata         | `repodata.json.zst` file  | application/vnd.conda.repodata.v1+json+zst  |
 | repodata         | `repodata.json.gz` file   | application/vnd.conda.repodata.v1+json+gzip |
 | repodata         | `repodata.json.bz2` file  | application/vnd.conda.repodata.v1+json+bz2  |
-| repodata         | `repodata.json.jlap` file | application/vnd.conda.jlap.v1               |
 
 If needed, more mediaTypes could be specified (i.e `application/vnd.conda.info.v1.tar+zst`).
 
@@ -70,12 +69,6 @@ Other encodings are also accepted:
 
 - `application/vnd.conda.repodata.v1+json+gzip`
 - `application/vnd.conda.repodata.v1+json+bz2`
-
-For `jlap`, the following mediaType is used:
-
-- `application/vnd.conda.jlap.v1`
-
-The `jlap` file should also be stored under the `<channel>/<subdir>/repodata.json` path as an additional layer.
 
 ### Conda package artifacts on an OCI registry
 

--- a/cep-oci.md
+++ b/cep-oci.md
@@ -50,7 +50,7 @@ All versions of the repodata should also be tagged  with a timestamp of the foll
 
 The mediaType for the raw `repodata.json` file is `application/vnd.conda.repodata.v1+json`. However, for large repositories it's advised to store the `zstd` encoded repodata file with the mediaType `application/vnd.conda.repodata.v1+json+zst` as an additional layer in `<channel>/<subdir>/repodata.json`.
 
-Other encoding are also accepted:
+Other encodings are also accepted:
 
 - `application/vnd.conda.repodata.v1+json+gzip`
 - `application/vnd.conda.repodata.v1+json+bz2`

--- a/cep-oci.md
+++ b/cep-oci.md
@@ -119,6 +119,12 @@ Some characters that are used in the conda-forge repository as part of the build
 - `!` is replaced by `__e__`
 - `=` is replaced by `__eq__`
 
+> [!IMPORTANT]
+> 
+> The mapping of the package names and tags, as previously outlined, is solely intended for internal storage within an OCI registry.
+> 
+> From the user's perspective, or in contexts outside of the OCI registry—beyond the middleware that interacts with it—, the package names and tags will remain unchanged, preserving the original strings.
+
 #### Authentication
 
 Pulling a public image from a Container registry can be done anonymously ([ref](https://docs.github.com/en/packages/learn-github-packages/about-permissions-for-github-packages#visibility-and-access-permissions-for-packages)).

--- a/cep-oci.md
+++ b/cep-oci.md
@@ -48,7 +48,7 @@ On an OCI registry it should be stored under `<channel>/<subdir>/repodata.json`.
 The repodata file should have one entry that has the `latest` tag. This entry should point to the latest version of the repodata.
 All versions of the repodata should also be tagged  with a timestamp of the following format: `YYYY.MM.DD.HH.MM`, e.g. `2024.04.12.07.06`.
 
-The mediaType for the raw `repodata.json` file is `application/vnd.conda.repodata.v1+json`. However, for large repositories it's advised to store the `zstd` encoded repodata file with the mediaType `application/vnd.conda.repodata.v1+json+zst`.
+The mediaType for the raw `repodata.json` file is `application/vnd.conda.repodata.v1+json`. However, for large repositories it's advised to store the `zstd` encoded repodata file with the mediaType `application/vnd.conda.repodata.v1+json+zst` as an additional layer in `<channel>/<subdir>/repodata.json`.
 
 Other encoding are also accepted:
 

--- a/cep-oci.md
+++ b/cep-oci.md
@@ -139,15 +139,9 @@ Note that in the case of pulling repodata, the name `repodata.json` is always us
 
 ##### mamba
 
-In order to fetch packages from an OCI registry, we need to set a mirror (can be more than one) for the channel to be used (e.g `conda-forge`).
-This can be done in the rc file as follows:
+In order to fetch packages from an OCI registry, the corresponding URL should be used as a channel (i.e `oci://ghcr.io/channel-mirrors/conda-forge`).
 
-```
-mirrored_channels:
-  conda-forge: ["oci://ghcr.io/channel-mirrors/conda-forge"]
-```
-
-When a user requests installing a package (with the configuration set above, and using `conda-forge` channel), a set of requests to fetch `repodata.json` are first performed as follows:
+When a user requests installing a package, a set of requests to fetch `repodata.json` are first performed as follows:
 
 - A token is requested to anonymously pull `repodata.json` using the following URL:\
 `https://ghcr.io/token?scope=repository:channel-mirrors/conda-forge/<subdir>/repodata.json:pull`

--- a/cep-oci.md
+++ b/cep-oci.md
@@ -1,0 +1,62 @@
+# OCI registries as conda channels
+
+We want to use OCI registries as a storage for conda packages. This CEP specifies how we lay out conda packages on an OCI registry.
+
+## Specification
+
+An OCI artifact consists of a manifest and a set of blobs. The manifest is a JSON document that describes the contents of the artifact. The blobs are the actual data that the manifest refers to. The manifest is stored in the registry as a blob, and the blobs are stored in the registry as blobs.
+
+The manifest consists of some metadata and a number of "layers". Each layer is a reference to a blob.
+
+Layers can have arbitrary names and mediaTypes.
+
+An OCI manifest is referenced by a name and a tag.
+
+### Conda package artifacts on an OCI registry
+
+The manifest for a conda package on an OCI registry should look like follows.
+
+It should have a name and a tag. The name is `<channel>/<subdir>/<package-name>`.
+The tag is the version and build string of the packages, using a `-` as a separator.
+
+For example, a package like `xtensor-0.10.4-h431234.conda` would map to a OCI registry `conda-forge/linux-64/xtensor:0.10.4-h431234`.
+
+### Layers
+
+A conda package, in an OCI registry, should ship up to 3 layers:
+
+- The package itself, as a tarball. (mandatory)
+- The package `info` folder as a gzipped "tar.gz" file.
+- The package `info/index.json` file as a plain JSON file.
+
+The mediaType for the different layers is as follows:
+
+- for a .tar.bz2 package, the mediaType is `application/vnd.conda.package.v1`
+- for a .conda package, the mediaType is `application/vnd.conda.package.v2`
+- for the `info` folder as gzip the mediaType is `application/vnd.conda.info.v1.tar+gzip`
+- for the `index.json` file the mediaType is `application/vnd.conda.info.index.v1+json`
+
+Using the `mediaType` field in the manifest, we can find the layer + SHA256 hash to pull the corresponding blob.
+Each `mediaType` should only be present in one layer.
+
+## Repodata on OCI registries
+
+The `repodata.json` file is a JSON file that contains metadata about the packages in a channel.
+It is used by conda to find packages in a channel.
+
+On an OCI registry it should be stored under `<channel>/<subdir>/repodata.json`.
+The repodata file should have one entry that has the `latest` tag. This entry should point to the latest version of the repodata.
+All versions of the repodata should also be tagged  with a timestamp of the following format: `YYYY.MM.DD.HH.MM`, e.g. `2024.04.12.07.06`.
+
+The mediaType for the raw `repodata.json` file is `application/vnd.conda.repodata.v1+json`. However, for large repositories it's advised to store the `zstd` encoded repodata file with the mediaType `application/vnd.conda.repodata.v1+json+zst`.
+
+Other encoding are also accepted:
+
+- `application/vnd.conda.repodata.v1+json+gzip`
+- `application/vnd.conda.repodata.v1+json+bz2`
+
+For `jlap`, the following mediaType is used:
+
+- `application/vnd.conda.jlap.v1`
+
+The `jlap` file should also be stored under the `<channel>/<subdir>/repodata.json` path as an additional layer.

--- a/cep-oci.md
+++ b/cep-oci.md
@@ -1,4 +1,14 @@
-# OCI registries as conda channels
+<table>
+<tr><td> Title </td><td> OCI registries as conda channels </td>
+<tr><td> Status </td><td> Proposed </td></tr>
+<tr><td> Author(s) </td><td> Wolf Vollprecht &lt;wolf@prefix.dev&gt;</td></tr>
+<tr><td> Created </td><td> April 12, 2024</td></tr>
+<tr><td> Updated </td><td> August 7, 2024</td></tr>
+<tr><td> Discussion </td><td> https://github.com/conda/ceps/pull/70 </td></tr>
+<tr><td> Implementation </td><td>  </td></tr>
+</table>
+
+# Abstract
 
 We want to use OCI registries as a storage for conda packages. This CEP specifies how we lay out conda packages on an OCI registry.
 

--- a/cep-oci.md
+++ b/cep-oci.md
@@ -12,6 +12,8 @@ Layers can have arbitrary names and mediaTypes.
 
 An OCI manifest is referenced by a name and a tag.
 
+For further details, please refer to the official [OCI Distribution spec](https://github.com/opencontainers/distribution-spec/blob/v1.0/spec.md#definitions).
+
 ### Conda package artifacts on an OCI registry
 
 The manifest for a conda package on an OCI registry should look like follows.
@@ -48,7 +50,7 @@ On an OCI registry it should be stored under `<channel>/<subdir>/repodata.json`.
 The repodata file should have one entry that has the `latest` tag. This entry should point to the latest version of the repodata.
 All versions of the repodata should also be tagged  with a UTC timestamp of the following format: `YYYY.MM.DD.HH.MM.SS`, e.g. `2024.04.12.07.06.32`.
 
-The mediaType for the raw `repodata.json` file is `application/vnd.conda.repodata.v1+json`. However, for large repositories it's advised to store the `zstd` encoded repodata file with the mediaType `application/vnd.conda.repodata.v1+json+zst` as an additional layer in `<channel>/<subdir>/repodata.json`.
+The mediaType for the raw `repodata.json` file is `application/vnd.conda.repodata.v1+json`. However, for large repositories it's advised to store the `zstd` encoded repodata file with the mediaType `application/vnd.conda.repodata.v1+json+zstd` as an additional layer in `<channel>/<subdir>/repodata.json`. ([ref](https://github.com/opencontainers/image-spec/blob/main/layer.md#gzip-media-types))
 
 Other encodings are also accepted:
 
@@ -60,3 +62,25 @@ For `jlap`, the following mediaType is used:
 - `application/vnd.conda.jlap.v1`
 
 The `jlap` file should also be stored under the `<channel>/<subdir>/repodata.json` path as an additional layer.
+
+### Mapping a conda-package to the OCI registry
+
+A given conda-package is identified by a URL like `<subdir>/<package-name>-<version>-<build>.<ext>` where `<subdir>` is the platform and architecture, `<package-name>` is the name of the package, `<version>` is the version of the package, `<build>` is the build string of the package, and `<ext>` is the extension of the package file.
+
+To store this package on an OCI registry, we need to map it to a name and tag. The name is `<channel>/<subdir>/<package-name>`. The tag is `<version>-<build>`. There are some special rules for OCI registry names and tags for which we need some mapping. The regex for valid names is as follows:
+
+`[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(\/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*` ([ref](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests))
+
+The regex expresses that names can only start with an alphanumeric letter.
+
+In `conda`, names can start with an underscore and it is used by conda-forge (e.g. `_libgcc_mutex`). For this reason, we replace a leading underscore with the string `zzz`.
+
+The tag is the version and build string of the packages, using a `-` as a separator. However, a OCI tag can only contain the following regex:
+
+`[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}`
+
+Some characters that are used in the conda-forge repository as part of the build string are not allowed in the OCI registry. For this reason, we use the following mapping:
+
+- `+` is replaced by `__p__`
+- `!` is replaced by `__e__`
+- `=` is replaced by `__eq__`

--- a/cep-oci.md
+++ b/cep-oci.md
@@ -46,7 +46,7 @@ It is used by conda to find packages in a channel.
 
 On an OCI registry it should be stored under `<channel>/<subdir>/repodata.json`.
 The repodata file should have one entry that has the `latest` tag. This entry should point to the latest version of the repodata.
-All versions of the repodata should also be tagged  with a timestamp of the following format: `YYYY.MM.DD.HH.MM`, e.g. `2024.04.12.07.06`.
+All versions of the repodata should also be tagged  with a UTC timestamp of the following format: `YYYY.MM.DD.HH.MM.SS`, e.g. `2024.04.12.07.06.32`.
 
 The mediaType for the raw `repodata.json` file is `application/vnd.conda.repodata.v1+json`. However, for large repositories it's advised to store the `zstd` encoded repodata file with the mediaType `application/vnd.conda.repodata.v1+json+zst` as an additional layer in `<channel>/<subdir>/repodata.json`.
 

--- a/cep-oci.md
+++ b/cep-oci.md
@@ -70,9 +70,11 @@ A given conda-package is identified by a URL like `<subdir>/<package-name>-<vers
 
 #### Mapping the package name
 
-> ![NOTE]
+> [!NOTE]
 > **Package names in the conda world**
-> The following regex is given by `conda/schemas` for a valid package name: `^[a-z0-9_](?!_)[._-]?([a-z0-9]+(\.|-|_|$))*$`
+> 
+> The following regex is given by [`conda/schemas`](https://github.com/conda/schemas/blob/473708ac97283708d6664cbd89b8049ad1623489/common-1.schema.json#L58-L82) for a valid package name: `^[a-z0-9_](?!_)[._-]?([a-z0-9]+(\.|-|_|$))*$`
+> 
 > That means, a package can start with an alphanumeric character or a _single_ underscore (not multiple), and can contain dots, dashes, and underscores. It also has to end with a alphanumeric character (cannot end with a dot, dash, or underscore).
 
 To store this package on an OCI registry, we need to map it to a name and tag. The name is `<channel>/<subdir>/<package-name>`. The tag is `<version>-<build>`. There are some special rules for OCI registry names and tags for which we need some mapping. The regex for valid names is as follows:


### PR DESCRIPTION
Fill in the technical details of the OCI registry storage for reference.