### PR TITLE
Update GHA and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -12,7 +12,7 @@ jobs:
   add_to_project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.0.4
+      - uses: actions/add-to-project@v1.0.1
         with:
           project-url: https://github.com/orgs/conda-incubator/projects/1
           github-token: ${{ secrets.CEPS_PROJECT_TOKEN }}


### PR DESCRIPTION
"Add to project" is failing possibly because that action is terribly outdated. Updating the version and adding dependabot to prevent this in the future.