### PR TITLE
Some editorial changes to make it prettier in conda.org and pre-commit hooks to enforce them

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+ignore-words-list = lief

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,18 @@ repos:
       types: [text]
       args: [--negate]
       files: cep-.+\.md
+    - id: cep-nodash
+      name: CEPs must be referred to with 'CEP N' (no dash)
+      entry: CEP-+\d+
+      language: pygrep
+      types: [text]
+      files: cep-.+\.md
+    - id: cep-nozero
+      name: CEPs must be referred to with 'CEP N' (no leading zeros)
+      entry: CEP[- ]+0+\d+
+      language: pygrep
+      types: [text]
+      files: cep-.+\.md
     - id: email-tags
       name: Email addresses must use &lt; and &gt;
       entry: <[^<>\s]+@[^<>\s]+>

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,12 @@ repos:
       types: [text]
       args: [--negate]
       files: cep-.+\.md
+    - id: email-tags
+      name: Email addresses must use &lt; and &gt;
+      entry: <[^<>\s]+@[^<>\s]+>
+      language: pygrep
+      types: [text]
+      files: cep-.+\.md
     - id: cep-filenames
       name: CEP filenames must be 'cep-XXXX.md'
       entry: CEP documents must be named '/cep-XXXX.md'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,6 @@
 # disable autofixing PRs, commenting "pre-commit.ci autofix" on a pull request triggers a autofix
 ci:
   autofix_prs: false
-# generally speaking we ignore all vendored code as well as tests data
-exclude: |
-  (?x)^(
-    tests/data/.* |
-    conda_libmamba_solver/mamba_utils\.py
-  )$
 repos:
   # generic verification and formatting
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -22,3 +16,18 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
+  - repo: local
+    hooks:
+    - id: cep-header
+      name: CEP must start with a '# CEP \d - Title' header
+      entry: ^# CEP \d+ - .+$
+      language: pygrep
+      types: [text]
+      args: [--negate]
+      files: cep-.+\.md
+    - id: cep-filenames
+      name: CEP filenames must be 'cep-XXXX.md'
+      entry: CEP documents must be named '/cep-XXXX.md'
+      language: fail
+      files: ^.*cep-.*\.md.*$
+      exclude: ^cep-\d{4}\.md$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,12 @@ repos:
       language: pygrep
       types: [text]
       files: cep-.+\.md
+    - id: cep-hrefs
+      name: Links to CEPs must be relative (no leading slash)
+      entry: '\(/cep-\d{4}\.md\)'
+      language: pygrep
+      types: [text]
+      files: cep-.+\.md
     - id: email-tags
       name: Email addresses must use &lt; and &gt;
       entry: <[^<>\s]+@[^<>\s]+>

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,12 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
+  - repo: https://github.com/codespell-project/codespell
+    # see setup.cfg
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        args: [--write-changes]
   - repo: local
     hooks:
     - id: cep-header

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Conda in the middle of a sentence:
 
 #### In titles and headers
 
-Titles and headers should use the same capitalization and formmating standards as sentences.
+Titles and headers should use the same capitalization and formatting standards as sentences.
 
 #### In links
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ for conda's implementation, all major changes should be submitted as
 | [0010](cep-0010.md) | Conda Version Support |
 | [0011](cep-0011.md) | Define the menuinst standard |
 | [0012](cep-0012.md) | Serving run_exports metadata in conda channels |
-| [0013](cep-0013.md) | A new recipe format - part 1 |
+| [0013](cep-0013.md) | A new recipe format – part 1 |
 | [0014](cep-0014.md) | A new recipe format – part 2 - the allowed keys & values |
 | [0015](cep-0015.md) | Hosting repodata.json and packages separately by adding a base_url property. |
 | [0016](cep-0016.md) | Sharded Repodata |
@@ -40,9 +40,9 @@ Community members are encouraged to author a CEP to suggest changes *before*
 any code is written to allow for the community to discuss the proposed changes.
 
 The formal process by which CEPs should be authored and how they are reviewed
-and resolved is specified in [CEP-1](https://github.com/conda/ceps/blob/main/cep-0001.md).
+and resolved is specified in [CEP 1](https://github.com/conda/ceps/blob/main/cep-0001.md).
 
-A template for new CEPs is given in [CEP-0](https://github.com/conda/ceps/blob/main/cep-0000.md).
+A template for new CEPs is given in [CEP 0](https://github.com/conda/ceps/blob/main/cep-0000.md).
 
 ## Conda capitalization standards
 

--- a/cep-0000.md
+++ b/cep-0000.md
@@ -1,3 +1,5 @@
+# CEP 0 - A short title of the proposal
+
 <table>
 <tr><td> Title </td><td> A short title of the proposal </td>
 <tr><td> Status </td><td> Draft | Proposed | Accepted | Rejected | Deferred | Implemented </td></tr>

--- a/cep-0000.md
+++ b/cep-0000.md
@@ -7,7 +7,7 @@
 <tr><td> Created </td><td> Aug 30, 2016</td></tr>
 <tr><td> Updated </td><td> Aug 30, 2016</td></tr>
 <tr><td> Discussion </td><td> link to the PR where the CEP is being discussed, NA is circulated initially </td></tr>
-<tr><td> Implementation </td><td> link to the PR for the implementation, NA if not availble </td></tr>
+<tr><td> Implementation </td><td> link to the PR for the implementation, NA if not available </td></tr>
 </table>
 
 ## Abstract

--- a/cep-0000.md
+++ b/cep-0000.md
@@ -18,17 +18,17 @@ A short description of the change being addressed.
 
 Other relevant sections of the proposal.  Common sections include:
 
-    * Specification -- The technical details of the proposed change.
-    * Motivation -- Why the proposed change is needed.
-    * Rationale -- Why particular decisions were made in the proposal.
-    * Backwards Compatibility -- Will the proposed change break existing
-      packages or workflows.
-    * Alternatives -- Any alternatives considered during the design.
-    * Sample Implementation -- Links to prototype or a sample implementation of
-      the proposed change.
-    * FAQ -- Frequently asked questions (and answers to them).
-    * Resolution -- A short summary of the decision made by the community.
-    * Reference -- Any references used in the design of the CEP.
+* Specification -- The technical details of the proposed change.
+* Motivation -- Why the proposed change is needed.
+* Rationale -- Why particular decisions were made in the proposal.
+* Backwards Compatibility -- Will the proposed change break existing
+  packages or workflows.
+* Alternatives -- Any alternatives considered during the design.
+* Sample Implementation -- Links to prototype or a sample implementation of
+  the proposed change.
+* FAQ -- Frequently asked questions (and answers to them).
+* Resolution -- A short summary of the decision made by the community.
+* Reference -- Any references used in the design of the CEP.
 
 ## Copyright
 

--- a/cep-0001.md
+++ b/cep-0001.md
@@ -111,17 +111,17 @@ This table should be followed by an **abstract** section and then
 additional sections as needed by the proposal. Some section that may be
 included if appropriate for the proposal include.
 
-    * Specification -- The technical details of the proposed change.
-    * Motivation -- Why the proposed change is needed.
-    * Rationale -- Why particular decisions were made in the proposal.
-    * Backwards Compatibility -- Will the proposed change break existing
-      packages or workflows.
-    * Alternatives -- Any alternatives considered during the design.
-    * Sample Implementation -- Links to prototype or a sample implementation of
-      the proposed change.
-    * FAQ -- Frequently asked questions (and answers to them).
-    * Resolution -- A short summary of the decision made by the community.
-    * Reference -- Any references used in the design of the CEP.
+* Specification -- The technical details of the proposed change.
+* Motivation -- Why the proposed change is needed.
+* Rationale -- Why particular decisions were made in the proposal.
+* Backwards Compatibility -- Will the proposed change break existing
+  packages or workflows.
+* Alternatives -- Any alternatives considered during the design.
+* Sample Implementation -- Links to prototype or a sample implementation of
+  the proposed change.
+* FAQ -- Frequently asked questions (and answers to them).
+* Resolution -- A short summary of the decision made by the community.
+* Reference -- Any references used in the design of the CEP.
 
 A final **copyright** section is also required.
 

--- a/cep-0001.md
+++ b/cep-0001.md
@@ -1,3 +1,5 @@
+# CEP 1 - Purpose and Guidelines
+
 <table>
 <tr><td> Title </td><td> CEP Purpose and Guidelines </td>
 <tr><td> Status </td><td> Proposed </td></tr>

--- a/cep-0002.md
+++ b/cep-0002.md
@@ -1,4 +1,4 @@
-# CEP 3 - Add plugin architecture to conda
+# CEP 2 - Add plugin architecture to conda
 
 <table>
 <tr><td> Title </td><td> Add plugin architecture to conda </td>

--- a/cep-0002.md
+++ b/cep-0002.md
@@ -3,7 +3,7 @@
 <table>
 <tr><td> Title </td><td> Add plugin architecture to conda </td>
 <tr><td> Status </td><td> Accepted </td></tr>
-<tr><td> Author(s) </td><td> Jannis Leidel &lt;jleidel@anaconda.com&lt;</td></tr>
+<tr><td> Author(s) </td><td> Jannis Leidel &lt;jleidel@anaconda.com&gt;</td></tr>
 <tr><td> Created </td><td> Jun 29, 2021</td></tr>
 <tr><td> Updated </td><td> Jun 30, 2021</td></tr>
 <tr><td> Discussion </td><td> https://github.com/conda/ceps/pull/1 </td></tr>

--- a/cep-0002.md
+++ b/cep-0002.md
@@ -1,3 +1,4 @@
+# CEP 3 - Add plugin architecture to conda
 
 <table>
 <tr><td> Title </td><td> Add plugin architecture to conda </td>

--- a/cep-0002.md
+++ b/cep-0002.md
@@ -3,7 +3,7 @@
 <table>
 <tr><td> Title </td><td> Add plugin architecture to conda </td>
 <tr><td> Status </td><td> Accepted </td></tr>
-<tr><td> Author(s) </td><td> Jannis Leidel <jleidel@anaconda.com></td></tr>
+<tr><td> Author(s) </td><td> Jannis Leidel &lt;jleidel@anaconda.com&lt;</td></tr>
 <tr><td> Created </td><td> Jun 29, 2021</td></tr>
 <tr><td> Updated </td><td> Jun 30, 2021</td></tr>
 <tr><td> Discussion </td><td> https://github.com/conda/ceps/pull/1 </td></tr>

--- a/cep-0003.md
+++ b/cep-0003.md
@@ -1,3 +1,5 @@
+# CEP 4 - Using the Mamba solver in conda
+
 <table>
 <tr><td> Title </td><td> Using the Mamba solver in conda </td>
 <tr><td> Status </td><td> Accepted </td></tr>

--- a/cep-0003.md
+++ b/cep-0003.md
@@ -91,7 +91,7 @@ returned by a helper function added to `conda.core.solve`
 
 > In a way, this means that the new solver class is _pre-registered_ as
 > a plugin, but must be installed separately. In the future, when the
-> plugin system described in CEP-2 is fully implemented, this manual
+> plugin system described in CEP 2 is fully implemented, this manual
 > integration could be replaced by the necessary plugin hooks.
 
 The default choice for the solver class must stay the same as long

--- a/cep-0003.md
+++ b/cep-0003.md
@@ -1,4 +1,4 @@
-# CEP 4 - Using the Mamba solver in conda
+# CEP 3 - Using the Mamba solver in conda
 
 <table>
 <tr><td> Title </td><td> Using the Mamba solver in conda </td>

--- a/cep-0004.md
+++ b/cep-0004.md
@@ -1,3 +1,5 @@
+# CEP 5 - Implement initial conda plugin mechanism
+
 <table>
 <tr><td> Title </td><td> Implement initial conda plugin mechanism </td>
 <tr><td> Status </td><td> Implemented  </td></tr>

--- a/cep-0004.md
+++ b/cep-0004.md
@@ -1,10 +1,9 @@
-# CEP 5 - Implement initial conda plugin mechanism
+# CEP 4 - Implement initial conda plugin mechanism
 
 <table>
 <tr><td> Title </td><td> Implement initial conda plugin mechanism </td>
 <tr><td> Status </td><td> Implemented  </td></tr>
-<tr><td> Author(s) </td><td> Bianca Henderson &lt;bhenderson@anaconda.com&gt;</td></tr>
-<tr><td> </td><td>Jannis Leidel &lt;jleidel@anaconda.com&gt; </td></tr>
+<tr><td> Author(s) </td><td> Bianca Henderson &lt;bhenderson@anaconda.com&gt;, Jannis Leidel &lt;jleidel@anaconda.com&gt; </td></tr>
 <tr><td> Created </td><td> July 5, 2022 </td></tr>
 <tr><td> Updated </td><td> August 22, 2022 </td></tr>
 <tr><td> Discussion </td><td>https://github.com/conda-incubator/ceps/pull/32</td></tr>

--- a/cep-0006.md
+++ b/cep-0006.md
@@ -1,3 +1,5 @@
+# CEP 6 - Add Channel Notices to conda
+
 <table>
     <tr><td> Title </td><td>Add Channel Notices to conda</td>
     <tr><td> Status </td><td>Accepted</td></tr>

--- a/cep-0008.md
+++ b/cep-0008.md
@@ -1,3 +1,5 @@
+# CEP 8 - Conda Release Schedule
+
 <table>
 <tr><td> Title </td><td> Conda Release Schedule </td>
 <tr><td> Status </td><td> Accepted </td></tr>

--- a/cep-0009.md
+++ b/cep-0009.md
@@ -17,14 +17,14 @@
 
 ## Abstract
 
-This CEP describes a deprecation schedule to properly warn about upcoming removals from the codebase. This policy expands on ideas and terminology defined in the [Conda Release Schedule (CEP-8)][cep8].
+This CEP describes a deprecation schedule to properly warn about upcoming removals from the codebase. This policy expands on ideas and terminology defined in the [Conda Release Schedule (CEP 8)][cep8].
 
 > **Note**
-> This CEP is only applicable for projects that have adopted the [Conda Release Schedule (CEP-8)][cep8].
+> This CEP is only applicable for projects that have adopted the [Conda Release Schedule (CEP 8)][cep8].
 
 ## Specification
 
-We propose a deprecation schedule that is slower than the [Conda Release Schedule (CEP-8)][cep8]. This is in acknowledgment of our diverse user groups (e.g. everything from per user per machine installs to multi-user installs on shared clusters).
+We propose a deprecation schedule that is slower than the [Conda Release Schedule (CEP 8)][cep8]. This is in acknowledgment of our diverse user groups (e.g. everything from per user per machine installs to multi-user installs on shared clusters).
 
 We define a new type of release, a deprecation release, to augment regular releases. A deprecation release occurs twice every year in March and September:
 

--- a/cep-0009.md
+++ b/cep-0009.md
@@ -1,3 +1,5 @@
+# CEP 9 - Conda Deprecation Schedule
+
 <table>
 <tr><td> Title </td><td> Conda Deprecation Schedule </td>
 <tr><td> Status </td><td> Accepted </td></tr>

--- a/cep-0010.md
+++ b/cep-0010.md
@@ -31,7 +31,7 @@ When a user is using a version older than the current version, we make no guaran
 patches for this release will be made. If bugs are encountered with this particular release,
 users will be encouraged to upgrade to the most recent release.
 
-The conda project already commits to maintain backwards compatibility per CEP-9.
+The conda project already commits to maintain backwards compatibility per CEP 9.
 Any breaking changes will be announced ahead of time and go through our established
 [deprecation schedule][deprecation-schedule].
 

--- a/cep-0010.md
+++ b/cep-0010.md
@@ -1,3 +1,5 @@
+# CEP 10 - Conda Version Support
+
 <table>
 <tr><td> Title </td><td> Conda Version Support </td>
 <tr><td> Status </td><td> Accepted </td></tr>

--- a/cep-0011.md
+++ b/cep-0011.md
@@ -1,3 +1,5 @@
+# CEP 11 - Define the `menuinst` standard
+
 <table>
 <tr><td> Title </td><td> Define the <code>menuinst</code> standard</td>
 <tr><td> Status </td><td> Accepted</td></tr>

--- a/cep-0011.md
+++ b/cep-0011.md
@@ -20,16 +20,16 @@
 `conda` packages. It operates by discovering certain JSON files located in `$PREFIX/Menu` after
 linking the package to the environment.
 
-This library has primarily targetted Windows. The original project supported Linux and MacOS, but
+This library has primarily targeted Windows. The original project supported Linux and MacOS, but
 `menuinst` was never used in practice on those platforms. As a result, the required JSON metadata
 diverged significantly in each platform, and the implementations were not kept up to date.
 
 This CEP will attempt to standardize the `menuinst` interface by:
 
 1. Providing a unified metadata schema for all platforms so a single document contains all the
-   metadata required to create shorcuts in all platforms.
+   metadata required to create shortcuts in all platforms.
 2. Enumerating the expected behavior for different configurations.
-3. Defining a programmatic interface for implementors (CLI / API).
+3. Defining a programmatic interface for implementers (CLI / API).
 
 ## Menu metadata schema
 
@@ -108,7 +108,7 @@ simplified overview of all possible keys and their default values:
           "desktop": true, # create desktop location
           "quicklaunch": true, # create quick launch shortcut too
           "file_extensions": None, # file extensions to associate with shortcut in registry
-          "url_protocols": None, # URI protocols to associate with shorcut in registry
+          "url_protocols": None, # URI protocols to associate with shortcut in registry
           "app_user_model_id": None, # Identifier used to associate processes with a taskbar icon
         }
       }
@@ -173,17 +173,17 @@ macOS            | `.app` directory | `~/Applications` | `/Applications` |
 Windows          | `.lnk` file | `{{ menu_name }}` directory inside Start Menu, Desktop, and/or Quick Launch | Start Menu | These locations are customizable and configured in the Windows registry.
 
 - On Linux, little needs to be done because XDG delegates the responsibility to the desktop
-  manager. The implementor only needs to create the `.desktop` file and adjust/add the menu XML
+  manager. The implementer only needs to create the `.desktop` file and adjust/add the menu XML
   file(s).
 - On macOS, we had to come up with some ideas. The shortcut is actually an `.app` directory.
-  Implementors must follow Apple's guidelines. See Addendum B for implementation details.
+  Implementers must follow Apple's guidelines. See Addendum B for implementation details.
 - On Windows, `.lnk` files are created with the Windows API. File type and URL protocol association
   is done in the [Windows
   registry](https://learn.microsoft.com/en-us/windows/win32/shell/fa-file-types).
 
 Some installations might provide two modes: "Current user only", and "All users". This option is
 not surfaced in the JSON metadata, but might be requested at creation time in the CLI or API. This
-means that implementors MUST be able to handle both user locations and system locations, as
+means that implementers MUST be able to handle both user locations and system locations, as
 detailed above. In particular, in-process permission elevation needs to be considered.
 
 When a package is removed, the file artifacts MUST be deleted too. If changes were done in other
@@ -191,13 +191,13 @@ resources (XML files on Linux, Registry on Windows), these MUST be undone too.
 
 ## CLI interface
 
-The implementor CLI is _not_ defined in this document. However, the integrations with `constructor`
+The implementer CLI is _not_ defined in this document. However, the integrations with `constructor`
 SHOULD be standardized if they are going to be kept in use.
 
 The proposed CLI (inspired by what's already in use to introduce minimal changes) is:
 
 ```shell
-${IMPLEMENTOR} constructor --prefix ${PREFIX} [--base-prefix ${BASE_PREFIX}] [--mode user|system] [--make-menus | --rm-menus] [pkg-name ...]
+${IMPLEMENTER} constructor --prefix ${PREFIX} [--base-prefix ${BASE_PREFIX}] [--mode user|system] [--make-menus | --rm-menus] [pkg-name ...]
 ```
 
 - `--make-menus` will create the menu items for the JSON files found in `$PREFIX/Menu`.
@@ -205,13 +205,13 @@ ${IMPLEMENTOR} constructor --prefix ${PREFIX} [--base-prefix ${BASE_PREFIX}] [--
 - If values are passed next to these two flags, only the JSON files that match those package names
   will be handled. Others will be ignored.
 - `--base-prefix` is optional and defaults to the value passed to `--prefix`. It is only needed
-  when `IMPLEMENTOR` is running from a location other than `--prefix` (e.g. `base` vs a custom
+  when `IMPLEMENTER` is running from a location other than `--prefix` (e.g. `base` vs a custom
   environment, or system Python and a virtual environment).
 - `--mode` is optional and defaults to the mark provided by the `--base-prefix` location. If a
   `.nonadmin` file is present there, `mode=user` will be assumed. Otherwise, `mode=system` will be
   assumed, with a fallback to `mode=user` if necessary.
 
-Alternatively, the `constructor` subcommand needs for menus can be dropped if `IMPLEMENTOR`
+Alternatively, the `constructor` subcommand needs for menus can be dropped if `IMPLEMENTER`
 supports new settings and/or CLI flags in the `create | install` commands. Namely:
 
 - `base_prefix`: override the assumed `base` environment location. This is nowadays available as
@@ -221,7 +221,7 @@ supports new settings and/or CLI flags in the `create | install` commands. Namel
   - `--shortcuts` would set `shortcuts=True`, which is the default otherwise.
   - `--no-shorcuts` would set `shortcuts=False`.
   - `--shortcuts pkg1 pkg2 ...` would set `shortcuts=[pkg1, pkg2, ...]`, which would instruct
-    `IMPLEMENTOR` to handle menu item creation or removal for those packages only.
+    `IMPLEMENTER` to handle menu item creation or removal for those packages only.
 
 ## Backwards compatibility
 
@@ -254,7 +254,7 @@ All CEPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdo
 ### `menuinst 1.x` pre-standard
 
 The required metadata for each platform is documented in [the `menuinst` wiki][wiki]. However, only
-Windows is really supported by the tool. This assymmetrical growth has allowed Windows to grow an
+Windows is really supported by the tool. This asymmetrical growth has allowed Windows to grow an
 ad-hoc specification that doesn't really translate well to other platforms.
 
 The overall schema seems to be:
@@ -371,7 +371,7 @@ implemented. Per-platform options are allowed but only when strictly necessary.
 - In some cases, if an external binary is required, it needs to be symlinked into the `.app`
   directory to ensure keyboard integrations work (see
   [`conda/menuinst#122`](https://github.com/conda/menuinst/issues/122)).
-- URL protocol association requires special support in the binary launcher. Implementors can choose
+- URL protocol association requires special support in the binary launcher. Implementers can choose
   how to implement it. [See this issue](https://github.com/conda/menuinst/issues/118) and
   [this PR](https://github.com/conda/menuinst/pull/119) for ideas.
 

--- a/cep-0012.md
+++ b/cep-0012.md
@@ -1,5 +1,7 @@
+# CEP 12 - Serving <code>run_exports</code> metadata in conda channels
+
 <table>
-<tr><td> Title </td><td> Serving run_exports metadata in conda channels </td>
+<tr><td> Title </td><td> Serving <code>run_exports</code> metadata in conda channels </td>
 <tr><td> Status </td><td> Accepted </td></tr>
 <tr><td> Author(s) </td>
 <td>

--- a/cep-0013.md
+++ b/cep-0013.md
@@ -1,7 +1,7 @@
-# A new Recipe format (Part 1)
+# CEP 13 - A new Recipe format (Part 1)
 
 <table>
-<tr><td> Title </td><td> A new recipe format </td>
+<tr><td> Title </td><td> A new recipe format (Part 1)</td>
 <tr><td> Status </td><td> Accepted </td></tr>
 <tr><td> Author(s) </td><td> Wolf Vollprecht &lt;wolf@prefix.dev&gt;</td></tr>
 <tr><td> Created </td><td> May 23, 2023</td></tr>

--- a/cep-0013.md
+++ b/cep-0013.md
@@ -38,7 +38,7 @@ The reason for a new spec are:
 - iron out some inconsistencies around multiple outputs (build vs. build/script
   and more)
 - remove any need for recursive parsing & solving
-- cater to needs for automation and dependency tree analysis via a determinstic
+- cater to needs for automation and dependency tree analysis via a deterministic
   format
 
 ## Major differences with conda-build

--- a/cep-0014.md
+++ b/cep-0014.md
@@ -1,4 +1,4 @@
-# CEP 14: A new recipe format – part 2 - the allowed keys & values
+# CEP 14 - A new recipe format – part 2 - the allowed keys & values
 
 <table>
 <tr><td> Title </td><td> A new recipe format – part 2 - the allowed keys & values </td>

--- a/cep-0014.md
+++ b/cep-0014.md
@@ -115,7 +115,7 @@ build:
   # What is valid in an `if:` condition is valid
   skip: [list of expressions]
 
-  # wether the package is a noarch package, and if yes, wether it is "generic" or "python"
+  # whether the package is a noarch package, and if yes, whether it is "generic" or "python"
   # defaults to null ("arch" package)
   noarch: Option<OneOf<"generic" | "python">>
 
@@ -177,7 +177,7 @@ build:
     # was `ignore_prefix_files`
     ignore: bool | [path] (defaults to false)
 
-    # wether to detect binary files with prefix or not
+    # whether to detect binary files with prefix or not
     # was `detect_binary_files_with_prefix`
     ignore_binary_files: bool (defaults to true on Unix and (always) false on Windows)
 
@@ -186,7 +186,7 @@ build:
     # linux only, list of rpaths (was rpath)
     rpaths: [path] (defaults to ['lib/'])
 
-    # wether to relocate binaries or not. If this is a list of paths, then
+    # whether to relocate binaries or not. If this is a list of paths, then
     # only the listed paths are relocated
     binary_relocation: bool (defaults to true) | [glob]
 

--- a/cep-0014.md
+++ b/cep-0014.md
@@ -1,4 +1,4 @@
-# A new recipe format – part 2 - the allowed keys & values
+# CEP 14: A new recipe format – part 2 - the allowed keys & values
 
 <table>
 <tr><td> Title </td><td> A new recipe format – part 2 - the allowed keys & values </td>
@@ -22,7 +22,7 @@ In this CEP, we define the allowed keys and values for the recipe.
 ## Motivation
 
 The conda-build format is currently under-specified. For the new format, we try to list all values
-and types in a single document and document them. This is part of a larger effort (see [CEP-13](/cep-0013.md) for the new YAML syntax).
+and types in a single document and document them. This is part of a larger effort (see [CEP-13](cep-0013.md) for the new YAML syntax).
 
 ## History
 

--- a/cep-0014.md
+++ b/cep-0014.md
@@ -22,7 +22,7 @@ In this CEP, we define the allowed keys and values for the recipe.
 ## Motivation
 
 The conda-build format is currently under-specified. For the new format, we try to list all values
-and types in a single document and document them. This is part of a larger effort (see [CEP-13](cep-0013.md) for the new YAML syntax).
+and types in a single document and document them. This is part of a larger effort (see [CEP 13](cep-0013.md) for the new YAML syntax).
 
 ## History
 

--- a/cep-0015.md
+++ b/cep-0015.md
@@ -1,6 +1,8 @@
+# CEP 15 - Hosting <code>repodata.json</code> and packages separately by adding a <code>base_url</code> property
+
 <table>
-<tr><td> Title </td><td> Hosting repodata.json and packages separately by adding a base_url property. </td>
-<tr><td> Status </td><td> Draft </td></tr>
+<tr><td> Title </td><td> Hosting <code>repodata.json</code> and packages separately by adding a <code>base_url</code> property </td>
+<tr><td> Status </td><td> Accepted </td></tr>
 <tr><td> Author(s) </td><td> Daniel Holth &lt;dholth@anaconda.com&gt;</td></tr>
 <tr><td> Created </td><td> Aug 24, 2023</td></tr>
 <tr><td> Updated </td><td> Jan 22, 2024</td></tr>

--- a/cep-0016.md
+++ b/cep-0016.md
@@ -25,7 +25,7 @@ The current repodata format is a JSON file that contains all the packages in a g
 3. **CDN friendly**: A CDN MUST be usable to cache the majority of the data. This reduces the operating cost of a channel.
 4. **Support authN and authZ**: It MUST be possible to implement authentication and authorization with little extra overhead.
 5. **Easy to implement**: It MUST be relatively straightforward to implement to ease the adoption in different tools.
-6. **Client-side cachable**: If a user has a hot cache the user SHOULD only have to download small incremental changes. Preferably as little communication as possible with the server should be required to check freshness of the data.
+6. **Client-side cacheable**: If a user has a hot cache the user SHOULD only have to download small incremental changes. Preferably as little communication as possible with the server should be required to check freshness of the data.
 7. **Bandwidth optimized**: Any data that is transferred SHOULD be as small as possible.
 
 ## Previous work
@@ -45,7 +45,7 @@ Finally, the implementation of JLAP is quite complex which makes it hard to adop
 
 A notable improvement is compressing the `repodata.json` with `zst` and serving that file. In practice this yields a file that is 20% of the original size (20-30 Mb for large cases). Although this is still quite a big file it's substantially smaller.
 
-However, the file still contains all repodata in the channel. This means the file needs to be redownloaded every time anyone adds a single package (even if a user doesnt need that package).
+However, the file still contains all repodata in the channel. This means the file needs to be redownloaded every time anyone adds a single package (even if a user doesn't need that package).
 
 Because the file is relatively big this means that often a large `max-age` is used for caching which means it takes more time to propagate new packages through the ecosystem.
 

--- a/cep-0016.md
+++ b/cep-0016.md
@@ -1,3 +1,5 @@
+# CEP 16 - Sharded Repodata
+
 <table>
 <tr><td> Title </td><td> Sharded Repodata </td>
 <tr><td> Status </td><td> Accepted </td></tr>

--- a/cep-0017.md
+++ b/cep-0017.md
@@ -1,6 +1,8 @@
+# CEP 17 - Optional Python site-packages path in repodata
+
 <table>
-<tr><td> Title </td><td> Optional python site-packages path in repodata </td>
-<tr><td> Status </td><td> Proposed </td></tr>
+<tr><td> Title </td><td> Optional Python site-packages path in repodata </td>
+<tr><td> Status </td><td> Accepted </td></tr>
 <tr><td> Author(s) </td><td> Jonathan Helmus &lt;jjhelmus@gmail.com&gt;</td></tr>
 <tr><td> Created </td><td> Sep 13, 2024</td></tr>
 <tr><td> Updated </td><td> Sep 13, 2024</td></tr>


### PR DESCRIPTION
Part of https://github.com/conda/conda-dot-org/pull/220. Preview at https://deploy-preview-220--conda-dot-org.netlify.app/community/ceps.

Changes:

- First line of the CEP must always be a `# CEP X - Title` header
- Links to other CEPs must be relative: `[CEP X](cep-000X.md)` instead of `[CEP X](/cep-000X.md)` (notice the absence of the leading slash).
- Some custom pre-commit hooks to enforce the above
- `codespell` checks and changes (caught a few typos!)
- Small cosmetic changes