### PR TITLE
CEP-11: Update schema with menuinst 2.1.x and 2.2.x changes

### DIFF
--- a/cep-0011.md
+++ b/cep-0011.md
@@ -5,7 +5,7 @@
 <tr><td> Status </td><td> Accepted</td></tr>
 <tr><td> Author(s) </td><td> Jaime Rodríguez-Guerra &lt;jaime.rogue@gmail.com&gt;</td></tr>
 <tr><td> Created </td><td> Oct 14, 2021</td></tr>
-<tr><td> Updated </td><td> Jul 28, 2023</td></tr>
+<tr><td> Updated </td><td> Nov 11, 2024</td></tr>
 <tr><td> Discussion </td><td> <a href="https://github.com/conda-incubator/ceps/pull/8" target="_blank">conda-incubator/ceps#8</a> </td></tr>
 <tr><td> Implementation </td><td> <a href="https://github.com/conda/menuinst/tree/cep-devel" target="_blank"><code>conda/menuinst</code>@<code>cep-devel</code></a> </td></tr>
 </table>
@@ -13,6 +13,10 @@
 > The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
   "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as
   described in [RFC2119][RFC2119] when, and only when, they appear in all capitals, as shown here.
+
+> This CEP was modified after acceptance:
+>
+> 2024-11-07: Updated to reflect latest changes in `menuinst` 2.1.x series.
 
 ## Abstract
 
@@ -44,6 +48,11 @@ simplified overview of all possible keys and their default values:
   "menu_items": [
     {
       "name": "REQUIRED",
+      # "name" can also be a dictionary:
+      # "name": {
+      #   "target_environment_is_base": "Name (base)",
+      #   "target_environment_is_not_base": "Name (not base)",
+      # },
       "description": "REQUIRED",
       "command": [
         "REQUIRED",
@@ -94,6 +103,7 @@ simplified overview of all possible keys and their default values:
           "LSMinimumSystemVersion": None,
           "LSMultipleInstancesProhibited": None,
           "LSRequiresNativeExecution": None,
+          "NSSupportsAutomaticGraphicsSwitching": None,
           "UTExportedTypeDeclarations": None,
           "UTImportedTypeDeclarations": None,
           #: list of permissions to request for the app
@@ -110,6 +120,7 @@ simplified overview of all possible keys and their default values:
           "file_extensions": None, # file extensions to associate with shortcut in registry
           "url_protocols": None, # URI protocols to associate with shortcut in registry
           "app_user_model_id": None, # Identifier used to associate processes with a taskbar icon
+          "terminal_profile": None, # create Windows Terminal profile
         }
       }
     }

--- a/cep-0011.md
+++ b/cep-0011.md
@@ -16,7 +16,7 @@
 
 > This CEP was modified after acceptance:
 >
-> Update 1 (2024-11-07): Updated to reflect latest changes in `menuinst` 2.1.x series.
+> Update 1 (2024-11-07): Updated to reflect latest changes in `menuinst` 2.1.x and 2.2.x series.
 
 ## Abstract
 
@@ -80,6 +80,7 @@ simplified overview of all possible keys and their default values:
           "NotShowIn": None,
           "OnlyShowIn": None,
           "PrefersNonDefaultGPU": None,
+          "SingleMainWindow": None,
           "StartupNotify": None,
           "StartupWMClass": None,
           "TryExec": None,
@@ -116,7 +117,7 @@ simplified overview of all possible keys and their default values:
         },
         "win": {
           "desktop": true, # create desktop location
-          "quicklaunch": true, # create quick launch shortcut too
+          "quicklaunch": false, # create quick launch shortcut too
           "file_extensions": None, # file extensions to associate with shortcut in registry
           "url_protocols": None, # URI protocols to associate with shortcut in registry
           "app_user_model_id": None, # Identifier used to associate processes with a taskbar icon

--- a/cep-0011.md
+++ b/cep-0011.md
@@ -16,7 +16,7 @@
 
 > This CEP was modified after acceptance:
 >
-> 2024-11-07: Updated to reflect latest changes in `menuinst` 2.1.x series.
+> Update 1 (2024-11-07): Updated to reflect latest changes in `menuinst` 2.1.x series.
 
 ## Abstract
 

--- a/cep-0011.md
+++ b/cep-0011.md
@@ -117,7 +117,7 @@ simplified overview of all possible keys and their default values:
         },
         "win": {
           "desktop": true, # create desktop location
-          "quicklaunch": false, # create quick launch shortcut too
+          "quicklaunch": false, # deprecated; create quick launch shortcut too
           "file_extensions": None, # file extensions to associate with shortcut in registry
           "url_protocols": None, # URI protocols to associate with shortcut in registry
           "app_user_model_id": None, # Identifier used to associate processes with a taskbar icon

--- a/cep-0011.md
+++ b/cep-0011.md
@@ -5,9 +5,9 @@
 <tr><td> Status </td><td> Accepted</td></tr>
 <tr><td> Author(s) </td><td> Jaime Rodríguez-Guerra &lt;jaime.rogue@gmail.com&gt;</td></tr>
 <tr><td> Created </td><td> Oct 14, 2021</td></tr>
-<tr><td> Updated </td><td> Nov 11, 2024</td></tr>
+<tr><td> Updated </td><td> Dec 14, 2024</td></tr>
 <tr><td> Discussion </td><td> <a href="https://github.com/conda-incubator/ceps/pull/8" target="_blank">conda-incubator/ceps#8</a> </td></tr>
-<tr><td> Implementation </td><td> <a href="https://github.com/conda/menuinst/tree/cep-devel" target="_blank"><code>conda/menuinst</code>@<code>cep-devel</code></a> </td></tr>
+<tr><td> Implementation </td><td> <a href="https://github.com/conda/menuinst" target="_blank"><code>conda/menuinst</code></a> </td></tr>
 </table>
 
 > The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
@@ -16,7 +16,7 @@
 
 > This CEP was modified after acceptance:
 >
-> Update 1 (2024-11-07): Updated to reflect latest changes in `menuinst` 2.1.x and 2.2.x series.
+> Update 1 (2024-12-14): Updated to reflect latest changes in `menuinst` 2.1.x, 2.2.x and 2.3.x series. This bumps the schema to version `1-1-0`.
 
 ## Abstract
 
@@ -42,8 +42,7 @@ simplified overview of all possible keys and their default values:
 
 ```python
 {
-  "$id": "https://schemas.conda.io/menuinst-1.schema.json",
-  "$schema": "https://json-schema.org/draft-07/schema",
+  "$schema": "https://schemas.conda.org/menuinst-1-1-0.schema.json",
   "menu_name": "REQUIRED",
   "menu_items": [
     {
@@ -132,7 +131,9 @@ simplified overview of all possible keys and their default values:
 Note that each `platforms` sub-dictionary (`linux`, `macos`, `win`) can override the global values
 of their `menu_items[*]` entry (e.g. redefining `command` to adjust the shell syntax).
 
-Each JSON file MUST be validated against its `$id` schema at build time; e.g in `conda-build`.
+Each JSON file MUST be validated against its `$schema` schema at build time; e.g in `conda-build`.
+
+The schema will be versioned using [SchemaVer](https://docs.snowplow.io/docs/api-reference/iglu/common-architecture/schemaver/). When omitted, the version is assumed to be in the `1-0-*` series.
 
 ## Placeholders
 
@@ -391,6 +392,6 @@ implemented. Per-platform options are allowed but only when strictly necessary.
 [wiki]:
     https://github.com/conda/menuinst/wiki/Menu-Shortcut-Config-Structure/632fbc84251c8a8093e1b56b0b5314d23c1e946b
 
-[menuinst-json-schema]: https://github.com/conda/menuinst/blob/cep-devel/menuinst/data/menuinst.schema.json
+[menuinst-json-schema]: https://github.com/conda/menuinst/blob/2.0.0/menuinst/data/menuinst.schema.json
 
 [RFC2119]: https://datatracker.ietf.org/doc/html/rfc2119

--- a/cep-0011.md
+++ b/cep-0011.md
@@ -63,7 +63,7 @@ simplified overview of all possible keys and their default values:
       "activate": true,  # activate conda environment before running 'command'
       "terminal": false, # open in terminal and leave it open
       "platforms": {
-        # To create the menu item for a fiven platform, the key must be present in this
+        # To create the menu item for a given platform, the key must be present in this
         # dictionary. Presence is enough; the value can just be the empty dictionary: {}.
         "linux": {
           # See XDG Desktop standard for details
@@ -128,7 +128,7 @@ simplified overview of all possible keys and their default values:
 }
 ```
 
-Note that each `platforms` sub-dictionary (`linux`, `macos`, `win`) can override the global values
+Note that each `platforms` sub-dictionary (`linux`, `osx`, `win`) can override the global values
 of their `menu_items[*]` entry (e.g. redefining `command` to adjust the shell syntax).
 
 Each JSON file MUST be validated against its `$schema` schema at build time; e.g in `conda-build`.


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

As discussed in #97, apparently this is ok to do. As you can see, it's just a backwards-compatible extensions to the schema.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
