### PR TITLE
MNT: Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,11 @@
 ## Checklist for submitter
 
-- [ ] I am submitting a new CEP.
+- [ ] I am submitting a new CEP: [Put your title here](#link-to-markdown-preview-in-branch).
   - [ ] I am using the CEP template by creating a copy `cep-0000.md` named `cep-????.md` in the root level.
-- [ ] I am submitting modifications to an existing CEP.
-- [ ] Something else.
+- [ ] I am submitting modifications to CEP XX. <!-- reflect CEP number here -->
+- [ ] Something else: (add your description here).
 
+<!-- delete section below if this is not a new CEP -->
 ## Checklist for CEP approvals
 
 - [ ] The vote period has ended and the vote has passed the necessary quorum and approval thresholds.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Checklist for submitter
 
 - [ ] I am submitting a new CEP: [Put your title here](#link-to-markdown-preview-in-branch).
-  - [ ] I am using the CEP template by creating a copy `cep-0000.md` named `cep-????.md` in the root level.
+  - [ ] I am using the CEP template by creating a copy `cep-0000.md` named `cep-XXXX.md` in the root level.
 - [ ] I am submitting modifications to CEP XX. <!-- reflect CEP number here -->
 - [ ] Something else: (add your description here).
 
@@ -10,8 +10,8 @@
 
 - [ ] The vote period has ended and the vote has passed the necessary quorum and approval thresholds.
 - [ ] A new CEP number has been minted. Usually, this is `${greatest-number-in-main} + 1`.
-- [ ] The `cep-????.md` file has been renamed accordingly.
-- [ ] The `# CEP XX - ` header has been edited accordingly.
+- [ ] The `cep-XXXX.md` file has been renamed accordingly.
+- [ ] The `# CEP XXXX - ` header has been edited accordingly.
 - [ ] The CEP status in the table has been changed to approved.
 - [ ] The last modification date in the table has been updated accordingly.
 - [ ] The `pre-commit` checks are passing.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,5 +24,5 @@
      let us know!
 
      Helpful links:
-       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
-       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->
+       - Conda Org COC: https://github.com/conda/governance/blob/main/CODE_OF_CONDUCT.md
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Checklist for submitter
+
+- [ ] I am submitting a new CEP.
+  - [ ] I am using the CEP template by creating a copy `cep-0000.md` named `cep-????.md` in the root level.
+- [ ] I am submitting modifications to an existing CEP.
+- [ ] Something else.
+
+## Checklist for CEP approvals
+
+- [ ] The vote period has ended and the vote has passed the necessary quorum and approval thresholds.
+- [ ] A new CEP number has been minted. Usually, this is `${greatest-number-in-main} + 1`.
+- [ ] The `cep-????.md` file has been renamed accordingly.
+- [ ] The `# CEP XX - ` header has been edited accordingly.
+- [ ] The CEP status in the table has been changed to approved.
+- [ ] The last modification date in the table has been updated accordingly.
+- [ ] The `pre-commit` checks are passing.
+
+
+<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
+     must follow the Conda Org Code of Conduct (link below).
+
+     Finally, once again, thanks for your time and effort. If you have any
+     feedback in regards to your experience contributing here, please
+     let us know!
+
+     Helpful links:
+       - Conda Org COC: https://github.com/conda/conda/blob/main/CODE_OF_CONDUCT.md
+       - Contributing docs: https://github.com/conda/conda/blob/main/CONTRIBUTING.md -->


### PR DESCRIPTION
Just to streamline the process a little bit. Just a suggestion, instead of the default template, which is used mostly for code contributions in `conda/conda` and similar repositories.