### PR TITLE
CEP-0014: permit lists in `context`

### DIFF
--- a/cep-0014.md
+++ b/cep-0014.md
@@ -5,7 +5,7 @@
 <tr><td> Status </td><td> Accepted</td></tr>
 <tr><td> Author(s) </td><td> Wolf Vollprecht &lt;wolf@prefix.dev&gt;</td></tr>
 <tr><td> Created </td><td> May 23, 2023</td></tr>
-<tr><td> Updated </td><td> Jan 22, 2024</td></tr>
+<tr><td> Updated </td><td> Feb 04, 2025</td></tr>
 <tr><td> Discussion </td><td> https://github.com/conda-incubator/ceps/pull/56 </td></tr>
 <tr><td> Implementation </td><td>https://github.com/prefix-dev/rattler-build</td></tr>
 </table>
@@ -68,7 +68,8 @@ To benefit from autocompletion, and other LSP features in editors, we can add a 
 ## Context section
 
 The context section is a dictionary with key-value pairs that can be used for string interpolation.
-The right-hand side of the key-value pair is a scalar (bool, number or string).
+The right-hand side of the key-value pair is either a scalar (bool, number or string), or a list of scalars.
+The resulting Jinja variable has the same type as the value.
 
 The variables can reference other variables from the context section.
 
@@ -84,6 +85,9 @@ context:
   variable: test
   # note that we can reference previous values, that means that they are rendered in order
   other_variable: test_${{ variable }}
+  sequence_variable:
+    - value1
+    - value2
 ```
 
 


### PR DESCRIPTION
### Description

Update the section describing the `context` block to permit lists of scalars in addition to scalars.  Add a note that the resulting Jinja variable will have the same type as the value.  For example, this can be used to declare lists of skipped tests, conveniently interspersing them with comments, and afterwards combining into a single string.

The change is backwards compatible and minimal, so it seems cleanest to update the specification in place rather than via another CEP.

See also: https://github.com/prefix-dev/rattler-build/pull/1402

CC @wolfv 