### PR TITLE
Draft another CEP for PURL annotation

### DIFF
--- a/cep-9999.md
+++ b/cep-9999.md
@@ -47,7 +47,6 @@ package:
 about:
   # ...
   purls:
-    - pkg:pypi/django
     - pkg:pypi/django@{{ version }}
 ```
 

--- a/cep-9999.md
+++ b/cep-9999.md
@@ -16,7 +16,7 @@ This CEP aims to standardize how the conda ecosystem can leverage free-form
 artifact metadata to annotate source and ecosystem provenance of the distributed
 artifacts. 
 
-We propose using the `extra` field in the recipe metadata to implement
+We propose using the `about` field in the recipe metadata to implement
 a `purl` field where one or more [Package URLs](https://github.com/package-url/purl-spec)
 (PURLs) can be specified.
 

--- a/cep-9999.md
+++ b/cep-9999.md
@@ -54,7 +54,7 @@ about:
 ## Specification
 
 The `about` section (top-level or output-specific) in the recipe file MAY
-contain a `purl` field that takes a string or a list of strings as specified
+contain a `purls` field that takes a list of strings as specified
 by the [PURL standard](https://github.com/package-url/purl-spec/blob/main/PURL-SPECIFICATION.rst).
 
 If the build tool does not support this new field in `about`, the free-form `extra`

--- a/cep-9999.md
+++ b/cep-9999.md
@@ -1,0 +1,65 @@
+# CEP ???? - Source provenance metadata
+
+<table>
+<tr><td> Title </td><td> CEP ???? -  Source provenance metadata </td>
+<tr><td> Status </td><td> Draft </td></tr>
+<tr><td> Author(s) </td><td> Jaime Rodríguez-Guerra &lt;jaime.rogue@gmail.com&gt;</td></tr>
+<tr><td> Created </td><td> Mar 10, 2025</td></tr>
+<tr><td> Updated </td><td> Mar 10, 2025</td></tr>
+<tr><td> Discussion </td><td> N/A </td></tr>
+<tr><td> Implementation </td><td> N/A </td></tr>
+</table>
+
+## Abstract
+
+This CEP aims to standardize how the conda ecosystem can leverage free-form
+artifact metadata to annotate source and ecosystem provenance of the distributed
+artifacts. 
+
+We propose using the `extra` field in the recipe metadata to implement
+a `purl` field where one or more [Package URLs](https://github.com/package-url/purl-spec)
+(PURLs) can be specified.
+
+## Motivation
+
+Provenance metadata is useful to assess from which sources an artifact was built.
+conda recipes already specify the necessary sources in their `source` section, but this field
+is mostly concerned with source download and preparation for the build. In
+most cases, it will contain one or more URLs or source-controlled repositories. These
+URLs cannot be guaranteed to uniquely identify a project since they may change, and their
+syntax might evolve across releases (e.g. different versioning schemes).
+
+Instead we propose adding a new field that _uniquely_ identifies the project being built.
+The Package URL project is chosen for this endeavour. This is speciallyuseful
+for efforts like dependency mapping across ecosystems. See
+[PEP 725](https://peps.python.org/pep-0725/) for practical applications in the
+context of PyPI <> conda interoperability.
+
+Example for `django`:
+
+```yaml
+# meta.yaml
+{% set version = "1.10.1" %}
+package: 
+  name: django
+  version: {{ version }}
+# ...
+about:
+  # ...
+  purls:
+    - pkg:pypi/django
+    - pkg:pypi/django@{{ version }}
+```
+
+## Specification
+
+The `about` section (top-level or output-specific) in the recipe file MAY
+contain a `purl` field that takes a string or a list of strings as specified
+by the [PURL standard](https://github.com/package-url/purl-spec/blob/main/PURL-SPECIFICATION.rst).
+
+If the build tool does not support this new field in `about`, the free-form `extra`
+section can be used instead for backwards-compatibility.
+
+## Copyright
+
+All CEPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Rehashing discussion in https://github.com/conda/ceps/pull/63, more focused on `about` rather than `index`.