### PR TITLE
fix: codify no number for draft ceps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
     - id: cep-header
       name: CEP must start with a '# CEP \d - Title' header
-      entry: ^# CEP (\d+|XXXX) - .+$
+      entry: ^# CEP (\d{1,4}|XXXX) - .+$
       language: pygrep
       types: [text]
       args: [--negate]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
     - id: cep-header
       name: CEP must start with a '# CEP \d - Title' header
-      entry: ^# CEP \d+ - .+$
+      entry: ^# CEP (\d+|XXXX) - .+$
       language: pygrep
       types: [text]
       args: [--negate]
@@ -60,4 +60,4 @@ repos:
       entry: CEP documents must be named '/cep-XXXX.md'
       language: fail
       files: ^.*cep-.*\.md.*$
-      exclude: ^cep-\d{4}\.md$
+      exclude: ^cep-(\d{4}|XXXX)\.md$

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A template for new CEPs is given in [CEP 0](https://github.com/conda/ceps/blob/m
 
 CEPs which are in draft/proposed form should have the number `XXXX` in both their PR title, CEP title, and filename.
 A number will be assigned to the CEP upon acceptance, and all references to the CEP should be updated to reflect the
-CEP's number.
+CEP's number. To refer to the CEP before it has a number, use its PR number or its title.
 
 ## Conda capitalization standards
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ and resolved is specified in [CEP 1](https://github.com/conda/ceps/blob/main/cep
 
 A template for new CEPs is given in [CEP 0](https://github.com/conda/ceps/blob/main/cep-0000.md).
 
+CEPs which are in draft/proposed form should have the number `XXXX` in both their PR title, CEP title, and filename.
+A number will be assigned to the CEP upon acceptance, and all references to the CEP should be updated to reflect the
+CEP's number.
+
 ## Conda capitalization standards
 
 1. Conda should be written in lowercase, whether in reference to the tool, ecosystem, packages, or organization.


### PR DESCRIPTION
@conda/steering-council This PR codifies a practice for numbering draft CEPS. In this version, we would give them the number XXXX and state that a number is assigned upon acceptance.

Thoughts?