### PR TITLE
fix: remove `about.license_url`

### DIFF
--- a/cep-0014.md
+++ b/cep-0014.md
@@ -534,8 +534,6 @@ about:
   license: string (SPDX enforced)
   # the license files
   license_file: path | [path] (relative paths are found in source directory _or_ recipe directory)
-  # URL that points to the license – just stored as metadata
-  license_url: url
 
   # URL to the homepage (used to be `home`)
   homepage: url
@@ -547,6 +545,7 @@ about:
   # REMOVED:
   # prelink_message:
   # license_family: string (deprecated due to SPDX)
+  # license_url: string (removed as it was unused in conda-build - not part of about.json)
   # identifiers: [string]
   # tags: [string]
   # keywords: [string]
@@ -832,3 +831,7 @@ extra:
   recipe-maintainers:
     - the_maintainer_bot
 ```
+
+## Changelog
+
+- September 24, 2025: Removed `about.license_url` as the field exists but is unused in `conda-build`.


### PR DESCRIPTION
We removed `about.license_url` in rattler-build because it was unused in `conda-build` and never made it into the `about.json` file as far as we can tell.

We could re-instate it later and define clearly whether it should be part of `about.json` or not.