### PR TITLE
Adopt API Conventions in Conda Code, Exempt non-API Code From Deprecation Schedule

### DIFF
--- a/cep-0099.md
+++ b/cep-0099.md
@@ -2,7 +2,7 @@
 
 <table>
 <tr><td> Title </td><td> Adopt API Conventions in Conda Code, Exempt non-API Code From Deprecation Schedule </td>
-<tr><td> Status </td><td> Draft </td></tr>
+<tr><td> Status </td><td> Proposed </td></tr>
 <tr><td> Author(s) </td><td> Daniel Holth &lt;dholth@anaconda.com&gt;</td></tr>
 <tr><td> Created </td><td> Dec 16, 2025</td></tr>
 <tr><td> Updated </td><td> Feb 25, 2025</td></tr>

--- a/cep-0099.md
+++ b/cep-0099.md
@@ -34,7 +34,7 @@ details in conda.
 
 ## Specification
 
-This CEP proposes that conda adopt the [Python Library
+This CEP proposes adopting the [Python Library
 Interface](https://typing.python.org/en/latest/spec/distributing.html#library-interface-public-and-private-symbols)
 convention for new code.
 
@@ -99,6 +99,11 @@ from conda._internal.frobnicate import Frobnicate as Frobnicate
 Other programmers, and type checkers, know they can use the `Frobnicate` class
 but should not reference `_value` or `helper1`, `helper2`. In turn, the
 developer has more freedom to refactor.
+
+## Counterexample
+
+Conda should maintain backwards compatibility when doing so does not cause a
+significant maintenance burden.
 
 ## Alternatives
 

--- a/cep-0099.md
+++ b/cep-0099.md
@@ -17,7 +17,7 @@ schedule, demarcated by following Python library conventions.
 
 ## Motivation
 
-[CEP-9](https://github.com/conda/ceps/blob/main/cep-0009.md) describes a
+[CEP 9](https://github.com/conda/ceps/blob/main/cep-0009.md) describes a
 deprecation schedule to warn about removals from the codebase but does not
 describe any part of conda's codebase that is exempt from the deprecation
 schedule. This 10-15 month deprecation cycle, applied to all symbols in the
@@ -29,7 +29,7 @@ for new code. Instead, most new code is not called from outside conda and should
 be allowed to change as needed between conda releases.
 
 By applying Python type-checker API conventions to codebases that fall under
-CEP-9, this proposal aims to create a place for experiments and implementation
+CEP 9, this proposal aims to create a place for experiments and implementation
 details in conda.
 
 ## Specification

--- a/cep-0099.md
+++ b/cep-0099.md
@@ -112,6 +112,11 @@ significant maintenance burden.
 * __Release fast-moving code as libraries__. A good idea but not suitable for
   code that is tightly coupled to conda.
 
+## Clarification
+
+Although non-Python codebases may have their own deprecation and API policies,
+CEP-9 and this CEP shall only apply to Python codebases.
+
 ## Prior Art
 
 `conda` has a `conda.api` module. The module provides a limited set of wrapper
@@ -120,7 +125,9 @@ functionality has to be sought elsewhere.
 
 `pip` refactored APIs into `pip._internal` in [version
 10.0.0](https://github.com/pypa/pip/blob/main/NEWS.rst#1000b1-2018-03-31),
-[issue #4696](https://github.com/pypa/pip/issues/4696).
+[issue #4696](https://github.com/pypa/pip/issues/4696). This refactor
+successfully made major improvements to `pip`, but the project was never able to
+re-introduce a public API.
 
 ## Copyright
 

--- a/cep-0099.md
+++ b/cep-0099.md
@@ -36,12 +36,20 @@ details in conda.
 
 This CEP proposes that conda adopt the [Python Library
 Interface](https://typing.python.org/en/latest/spec/distributing.html#library-interface-public-and-private-symbols)
-convention for new code. 
+convention for new code.
 
-> * Symbols whose names begin with an underscore (but are not dunder names) are considered private.
-> * Imported symbols are considered private by default. A fixed set of [import forms](https://typing.python.org/en/latest/spec/distributing.html#import-conventions) re-export imported> symbols.
-> * A module can expose an __all__ symbol at the module level that provides a list of names that are considered part of the interface. This overrides all other rules above, allowing imported symbols or symbols whose names begin with an underscore to be included in the interface.
-> * Local variables within a function (including nested functions) are always considered private.
+From that document,
+> * Symbols whose names begin with an underscore (but are not dunder names) are
+>   considered private.
+> * Imported symbols are considered private by default. A fixed set of [import
+>   forms](https://typing.python.org/en/latest/spec/distributing.html#import-conventions)
+>   re-export imported symbols.
+> * A module can expose an __all__ symbol at the module level that provides a
+>   list of names that are considered part of the interface. This overrides all
+>   other rules above, allowing imported symbols or symbols whose names begin
+>   with an underscore to be included in the interface.
+> * Local variables within a function (including nested functions) are always
+>   considered private.
 
 Python type checkers understand these conventions
 and can let developers know if they are using conda's public interface.
@@ -60,9 +68,9 @@ with the conda release cycle.
 
 ## Alternatives
 
-- **Explicitly mark code as private or internal based on decorators**. Not
+* __Explicitly mark code as private or internal based on decorators__. Not
   supported by type checkers.
-- **Release fast-moving code as libraries**. A good idea but not suitable for
+* __Release fast-moving code as libraries__. A good idea but not suitable for
   code that is tightly coupled to conda.
 
 ## Prior Art

--- a/cep-0099.md
+++ b/cep-0099.md
@@ -76,10 +76,9 @@ with the conda release cycle.
 
 ## Prior Art
 
-`conda` has a nearly useless `conda.api` module. The module provides a limited
-set of wrapper classes that delegate to conda internals. There is no incentive
-to use `conda.api` over other parts of the code base or to maintain a clearly
-defined API.
+`conda` has a `conda.api` module. The module provides a limited set of wrapper
+classes that delegate to conda internals, but most "conda as a library"
+functionality has to be sought elsewhere.
 
 `pip` refactored APIs into `pip._internal` in [version
 10.0.0](https://github.com/pypa/pip/blob/main/NEWS.rst#1000b1-2018-03-31),

--- a/cep-0099.md
+++ b/cep-0099.md
@@ -1,0 +1,77 @@
+# CEP 99 - Changes to Conda Deprecation Schedule
+
+<table>
+<tr><td> Title </td><td> Changes to the Conda Deprecation Schedule </td>
+<tr><td> Status </td><td> Draft </td></tr>
+<tr><td> Author(s) </td><td> Daniel Holth &lt;dholth@anaconda.com&gt;</td></tr>
+<tr><td> Created </td><td> Dec 16, 2025</td></tr>
+<tr><td> Updated </td><td> Dec 16, 2025</td></tr>
+<tr><td> Discussion </td><td> NA </td></tr>
+<tr><td> Implementation </td><td> NA </td></tr>
+</table>
+
+## Abstract
+
+Defines portions of the conda codebase that are not subject to the deprecation
+schedule, demarcated by following Python library conventions.
+
+## Motivation
+
+[CEP-9](https://github.com/conda/ceps/blob/main/cep-0009.md) describes a
+deprecation schedule to warn about removals from the codebase but does not
+describe any part of conda's codebase that is exempt from the deprecation
+schedule. This 10-15 month deprecation cycle, applied to all symbols in the
+codebase, is an unnecessary barrier to change.
+
+At the time it was not unreasonable to assume that any part of conda could have
+been used as a library by unknown dependents, but this is not a good assumption
+for new code. Instead, most new code is not called from outside conda and should
+be allowed to change as needed between conda releases.
+
+By applying Python type-checker API conventions to codebases that fall under
+CEP-9, this proposal aims to create a place for experiments and implementation
+details in conda.
+
+## Specification
+
+This CEP proposes that conda adopt the [Python Library
+Interface](https://typing.python.org/en/latest/spec/distributing.html#library-interface-public-and-private-symbols)
+convention for new code. In this convention underscore-prefixed symbols are
+considered private and are not part of the library's interface but `__all__`
+overrides these rules. Symbols may be re-exported into the public interface with
+forms like `import X as X`. Python type checkers understand these conventions
+and can let developers know if they are using conda's public interface.
+
+Newly added private code would not be subject to the deprecation policy. This
+code could change as necessary instead of after a deprecation cycle.
+
+Private portions of newly-added public modules, i.e. underscore-prefixed symbols
+and class members or anything not in an `__all__` list, would also be permitted
+to change at any time.
+
+This proposal allows conda maintainers to add a top-level `_conda` for code that
+needs to bypass all import-time side effects and a `conda._internal` or other
+private namespace(s) for implementation details that can be changed in lockstep
+with the conda release cycle.
+
+## Alternatives
+
+- **Explicitly mark code as private or internal based on decorators**. Not
+  supported by type checkers.
+- **Release fast-moving code as libraries**. A good idea but not suitable for
+  code that is tightly coupled to conda.
+
+## Prior Art
+
+`conda` has a nearly useless `conda.api` module. The module provides a limited
+set of wrapper classes that delegate to conda internals. There is no incentive
+to use `conda.api` over other parts of the code base or to maintain a clearly
+defined API.
+
+`pip` refactored APIs into `pip._internal` in [version
+10.0.0](https://github.com/pypa/pip/blob/main/NEWS.rst#1000b1-2018-03-31),
+[issue #4696](https://github.com/pypa/pip/issues/4696).
+
+## Copyright
+
+All CEPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/cep-0099.md
+++ b/cep-0099.md
@@ -6,7 +6,7 @@
 <tr><td> Author(s) </td><td> Daniel Holth &lt;dholth@anaconda.com&gt;</td></tr>
 <tr><td> Created </td><td> Dec 16, 2025</td></tr>
 <tr><td> Updated </td><td> Feb 25, 2025</td></tr>
-<tr><td> Discussion </td><td> https://github.com/conda/ceps/pull/143 </td></tr>
+<tr><td> Discussion </td><td> https://github.com/conda/ceps/pull/143, <a href="https://conda.zulipchat.com/#narrow/channel/457620-ceps/topic/Changes.20to.20Conda.20Deprecation.20Schedule/with/575799191">Zulip Thread</a> </td></tr>
 <tr><td> Implementation </td><td> NA </td></tr>
 </table>
 

--- a/cep-0099.md
+++ b/cep-0099.md
@@ -67,6 +67,39 @@ needs to bypass all import-time side effects and a `conda._internal` or other
 private namespace(s) for implementation details that can be changed in lockstep
 with the conda release cycle.
 
+## Example
+
+A new module "conda._internal.frobnicate" contains
+
+```
+def helper1(a):
+  return a ** 4
+
+def helper2(a):
+  return a / 2
+
+class Frobnicate:
+  def __init__(self, value):
+    self._value = value
+
+  def frobnicate(self, a):
+    if a < 4:
+      return helper1(a)
+    else:
+      return helper2(a)
+```
+
+The developer thinks the new class should be an API, and creates a module
+`conda.frobnicate` with
+
+```
+from conda._internal.frobnicate import Frobnicate as Frobnicate
+```
+
+Other programmers, and type checkers, know they can use the `Frobnicate` class
+but should not reference `_value` or `helper1`, `helper2`. In turn, the
+developer has more freedom to refactor.
+
 ## Alternatives
 
 * __Explicitly mark code as private or internal based on decorators__. Not

--- a/cep-0099.md
+++ b/cep-0099.md
@@ -1,19 +1,20 @@
-# CEP 99 - Changes to Conda Deprecation Schedule
+# CEP 99 - Adopt Library Conventions in Conda Code, Exempt Private Code From Deprecation Schedule
 
 <table>
-<tr><td> Title </td><td> Changes to the Conda Deprecation Schedule </td>
+<tr><td> Title </td><td> Adopt API Conventions in Conda Code, Exempt non-API Code From Deprecation Schedule </td>
 <tr><td> Status </td><td> Draft </td></tr>
 <tr><td> Author(s) </td><td> Daniel Holth &lt;dholth@anaconda.com&gt;</td></tr>
 <tr><td> Created </td><td> Dec 16, 2025</td></tr>
-<tr><td> Updated </td><td> Dec 16, 2025</td></tr>
-<tr><td> Discussion </td><td> NA </td></tr>
+<tr><td> Updated </td><td> Feb 25, 2025</td></tr>
+<tr><td> Discussion </td><td> https://github.com/conda/ceps/pull/143 </td></tr>
 <tr><td> Implementation </td><td> NA </td></tr>
 </table>
 
 ## Abstract
 
-Defines portions of the conda codebase that are not subject to the deprecation
-schedule, demarcated by following Python library conventions.
+Follow Python library interface conventions in conda and codebases under the CEP
+9 deprecation schedule. Symbols marked as "private" under these conventions will
+not be subject to the deprecation schedule.
 
 ## Motivation
 
@@ -31,6 +32,9 @@ be allowed to change as needed between conda releases.
 By applying Python type-checker API conventions to codebases that fall under
 CEP 9, this proposal aims to create a place for experiments and implementation
 details in conda.
+
+By providing an explicit way to expose API from conda, users can benefit from an
+intentionally designed API surface when using conda as a library.
 
 ## Specification
 

--- a/cep-0099.md
+++ b/cep-0099.md
@@ -71,7 +71,7 @@ with the conda release cycle.
 
 A new module "conda._internal.frobnicate" contains
 
-```
+```python
 def helper1(a):
   return a ** 4
 
@@ -92,7 +92,7 @@ class Frobnicate:
 The developer thinks the new class should be an API, and creates a module
 `conda.frobnicate` with
 
-```
+```python
 from conda._internal.frobnicate import Frobnicate as Frobnicate
 ```
 

--- a/cep-0099.md
+++ b/cep-0099.md
@@ -115,7 +115,7 @@ significant maintenance burden.
 ## Clarification
 
 Although non-Python codebases may have their own deprecation and API policies,
-CEP-9 and this CEP shall only apply to Python codebases.
+CEP 9 and this CEP shall only apply to Python codebases.
 
 ## Prior Art
 

--- a/cep-0099.md
+++ b/cep-0099.md
@@ -39,6 +39,7 @@ Interface](https://typing.python.org/en/latest/spec/distributing.html#library-in
 convention for new code.
 
 From that document,
+>
 > * Symbols whose names begin with an underscore (but are not dunder names) are
 >   considered private.
 > * Imported symbols are considered private by default. A fixed set of [import

--- a/cep-0099.md
+++ b/cep-0099.md
@@ -111,6 +111,8 @@ significant maintenance burden.
   supported by type checkers.
 * __Release fast-moving code as libraries__. A good idea but not suitable for
   code that is tightly coupled to conda.
+* [Retract CEP 9](https://github.com/conda/ceps/pull/152), move policy decisions
+  to conda developer team.
 
 ## Clarification
 

--- a/cep-0099.md
+++ b/cep-0099.md
@@ -36,10 +36,14 @@ details in conda.
 
 This CEP proposes that conda adopt the [Python Library
 Interface](https://typing.python.org/en/latest/spec/distributing.html#library-interface-public-and-private-symbols)
-convention for new code. In this convention underscore-prefixed symbols are
-considered private and are not part of the library's interface but `__all__`
-overrides these rules. Symbols may be re-exported into the public interface with
-forms like `import X as X`. Python type checkers understand these conventions
+convention for new code. 
+
+> * Symbols whose names begin with an underscore (but are not dunder names) are considered private.
+> * Imported symbols are considered private by default. A fixed set of [import forms](https://typing.python.org/en/latest/spec/distributing.html#import-conventions) re-export imported> symbols.
+> * A module can expose an __all__ symbol at the module level that provides a list of names that are considered part of the interface. This overrides all other rules above, allowing imported symbols or symbols whose names begin with an underscore to be included in the interface.
+> * Local variables within a function (including nested functions) are always considered private.
+
+Python type checkers understand these conventions
 and can let developers know if they are using conda's public interface.
 
 Newly added private code would not be subject to the deprecation policy. This


### PR DESCRIPTION
## Checklist for submitter

- [x] I am submitting a new CEP: [Changes to Conda Deprecation Schedule](https://github.com/dholth/ceps/blob/change-deprecation/cep-0099.md).
  - [x] I am using the CEP template by creating a copy `cep-0000.md` named `cep-XXXX.md` in the root level.
- [ ] I am submitting modifications to CEP XX. <!-- reflect CEP number here -->
- [ ] Something else: (add your description here).

<!-- delete section below if this is not a new CEP -->
## Checklist for CEP approvals

- [ ] The vote period has ended and the vote has passed the necessary quorum and approval thresholds.
- [ ] A new CEP number has been minted. Usually, this is `${greatest-number-in-main} + 1`.
- [ ] The `cep-XXXX.md` file has been renamed accordingly.
- [ ] The `# CEP XXXX - ` header has been edited accordingly.
- [ ] The CEP status in the table has been changed to approved.
- [ ] The last modification date in the table has been updated accordingly.
- [ ] The table in the README has been updated with the new CEP entry.
- [x] The `pre-commit` checks are passing.


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/governance/blob/main/CODE_OF_CONDUCT.md
-->
