### PR TITLE
CEP 21: Rename 'run_export' to 'run_exports' in proposal

### DIFF
--- a/cep-0021.md
+++ b/cep-0021.md
@@ -36,9 +36,9 @@ We propose that these reasons no longer hold with [sharded repodata](https://git
 
 **It would require extending the repodata schema, currently not formally standardized.**
 
-We propose to add a `run_export` field to each record that mimics the specification from CEP 12.
+We propose to add a `run_exports` field to each record that mimics the specification from CEP 12.
 
-If the `run_export` field is not present in the record it means no `run_export` information is stored with the record, and a fallback mechanism should be used to acquire the run-export information.
+If the `run_exports` field is not present in the record it means no `run_exports` information is stored with the record, and a fallback mechanism should be used to acquire the run-export information.
 
 Since *adding* a field will not break existing parsers we feel this is safe and does not require a schema change.
 


### PR DESCRIPTION
Is this how the key has been implemented in PackageRecord?

## Checklist for submitter

- [ ] I am submitting a new CEP: [Put your title here](#link-to-markdown-preview-in-branch).
  - [ ] I am using the CEP template by creating a copy `cep-0000.md` named `cep-XXXX.md` in the root level.
- [x] I am submitting modifications to CEP 21. <!-- reflect CEP number here -->
- [ ] Something else: (add your description here).

<!-- delete section below if this is not a new CEP -->
## Checklist for CEP approvals

- [ ] The vote period has ended and the vote has passed the necessary quorum and approval thresholds.
- [ ] A new CEP number has been minted. Usually, this is `${greatest-number-in-main} + 1`.
- [ ] The `cep-XXXX.md` file has been renamed accordingly.
- [ ] The `# CEP XXXX - ` header has been edited accordingly.
- [ ] The CEP status in the table has been changed to approved.
- [ ] The last modification date in the table has been updated accordingly.
- [ ] The table in the README has been updated with the new CEP entry.
- [ ] The `pre-commit` checks are passing.


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/governance/blob/main/CODE_OF_CONDUCT.md
-->
