### PR TITLE
CEP 44: fix invalid character range in group name regex

### DIFF
--- a/cep-0044.md
+++ b/cep-0044.md
@@ -36,7 +36,7 @@ The chosen keyword in CEP 29 `MatchSpec`, keywords is `extras` given its popular
 
 ## Specification
 
-The `info/index.json` dictionary of each conda artifact MUST allow a new field, `extra-depends`, the value of which MUST be a dictionary that maps the group names (expressed as a string that MUST match the regex `[a-z0-9_.-+]{1,64}`) to a list of `MatchSpec` strings encoding the optional dependencies. Since this is backwards incompatible behavior-wise, the `schema_version` value MUST be bumped to `3`.
+The `info/index.json` dictionary of each conda artifact MUST allow a new field, `extra-depends`, the value of which MUST be a dictionary that maps the group names (expressed as a string that MUST match the regex `[a-z0-9_.+-]{1,64}`) to a list of `MatchSpec` strings encoding the optional dependencies. Since this is backwards incompatible behavior-wise, the `schema_version` value MUST be bumped to `3`.
 
 The `extras` field MUST also be exposed in recipe formats v1 and above, under the `requirements.extras` section (sibling to `build`, `host`, `run`, etc), that renders to the same schema (`dict[str, list[MatchSpec]]`).
 

--- a/cep-0044.md
+++ b/cep-0044.md
@@ -101,3 +101,7 @@ PEP 735 "optional dependency groups" are not covered in this CEP. Those are not 
 ## Copyright
 
 All CEPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).
+
+## Changelog
+
+- May 29, 2026: Fixed regex for valid extra group names.


### PR DESCRIPTION
Inside a regex character class (the square brackets [...]), the hyphen - is a special character used to define a range (like a-z or 0-9).

By placing it at the very end, it is interpreted as character instead