### PR TITLE
CEP 38: Amend `timestamp` definition

### DIFF
--- a/cep-0038.md
+++ b/cep-0038.md
@@ -5,8 +5,8 @@
 <tr><td> Status </td><td> Accepted </td></tr>
 <tr><td> Author(s) </td><td> Jaime Rodríguez-Guerra &lt;jaime.rogue@gmail.com&gt;</td></tr>
 <tr><td> Created </td><td> Nov 5, 2025 </td></tr>
-<tr><td> Updated </td><td> Mar 4, 2026 </td></tr>
-<tr><td> Discussion </td><td> https://github.com/conda/ceps/pull/140 </td></tr>
+<tr><td> Updated </td><td> Jun 8, 2026 </td></tr>
+<tr><td> Discussion </td><td> https://github.com/conda/ceps/pull/140, https://github.com/conda/ceps/pull/172 </td></tr>
 <tr><td> Implementation </td><td> https://github.com/conda/conda-index/blob/0.7.0/conda_index/index/__init__.py#L818 </td></tr>
 <tr><td> Requires </td><td> CEP 34 </td></tr>
 </table>

--- a/cep-0038.md
+++ b/cep-0038.md
@@ -49,7 +49,7 @@ If present, this JSON document MUST be served at the root of the conda channel (
   - `subdirs: list[str]`. Required. Channel subdirectories under which this package is available.
   - `summary: str`. Optional. Short description of the project.
   - `text_prefix: bool`. Required. Whether the package files contain a prefix placeholder that must be replaced in text mode.
-  - `timestamp: int`. Required. Upload date of the most recently published artifact, as a POSIX timestamp in milliseconds.
+  - `timestamp: int`. Required. Most recent `timestamp` value of all given records for this name, as a POSIX timestamp in seconds.
   - `version: str`. Required. Most recent version published in the channel.
 
 ## Rationale
@@ -63,6 +63,10 @@ The `channeldata.json` file is considered optional because the listed metadata m
 ## References
 
 - <https://docs.conda.io/projects/conda-build/en/stable/concepts/generating-index.html>
+
+## Changelog
+
+- 2026-06-08: Fix definition of `timestamp`, as per the [implementation](https://github.com/conda/conda-index/blob/90ea92e548316a8200dcb4d8c887fb3e13cf6d5d/conda_index/index/__init__.py#L1244-L1249) in `conda-index 0.11`.
 
 ## Copyright
 


### PR DESCRIPTION
## Checklist for submitter

- [ ] I am submitting a new CEP: [Put your title here](#link-to-markdown-preview-in-branch).
  - [ ] I am using the CEP template by creating a copy `cep-0000.md` named `cep-XXXX.md` in the root level.
- [X] I am submitting modifications to CEP XX. <!-- reflect CEP number here -->
  - [x] The PR title reflects the CEP I'm modifying: `CEP XX: Amend XYZ`.
  - [X] I updated the "Updated" date.
  - [x] I added the link of this PR to the Discussions row.
  - [X] I added or extended the `## Changelog` section right above the final "Copyright" section with an item that uses syntax `YYYY-MM-DD: Brief explanation of changes`.
- [ ] Something else: (add your description here).

Comes from conversation in https://github.com/conda/ceps/pull/154/files#r3373193626.