### PR TITLE
CEP 34: Require that {pre,post}-link and pre-unlink scripts are executed

### DIFF
--- a/cep-0034.md
+++ b/cep-0034.md
@@ -5,7 +5,7 @@
 <tr><td> Status </td><td> Accepted </td></tr>
 <tr><td> Author(s) </td><td> Jaime Rodríguez-Guerra &lt;jaime.rogue@gmail.com&gt;</td></tr>
 <tr><td> Created </td><td> Sep 27, 2025</td></tr>
-<tr><td> Updated </td><td> Mar 4, 2026</td></tr>
+<tr><td> Updated </td><td> Jun 11, 2026</td></tr>
 <tr><td> Discussion </td><td> https://github.com/conda/ceps/pull/133 </td></tr>
 <tr><td> Implementation </td><td> N/A </td></tr>
 <tr><td> Requires </td><td> CEP 29, CEP 31, CEP 32, CEP 33 </td></tr>
@@ -256,12 +256,12 @@ The following files and directories MUST be handled by the conda client:
 
 ### Pre- and post-link/unlink scripts
 
-The `./bin/` and `./Scripts/` directories usually contain executables populated by the packages themselves. There are four special paths that MAY be handled by conda clients. For files named like `.{package-name}-{action}.{extension}`, where `{package-name}` corresponds to the package name and `{extension}` is either `sh` (Unix) or `bat` (Windows), there are four possible `{action}` values and associated behaviors:
+The `./bin/` and `./Scripts/` directories usually contain executables populated by the packages themselves. For files named like `.{package-name}-{action}.{extension}`, where `{package-name}` corresponds to the package name and `{extension}` is either `sh` (Unix) or `bat` (Windows), there are four possible `{action}` values and associated behaviors:
 
-- `pre-link`: Executed before a package is installed / linked.
-- `post-link`: Executed after a package is installed / linked.
-- `pre-unlink`: Executed before a package is removed / unlinked.
-- `post-unlink`: Executed after a package is removed / unlinked. Deprecated; MAY be ignored.
+- `pre-link`: The script MUST be executed before a package is installed / linked.
+- `post-link`: The script MUST be executed after a package is installed / linked.
+- `pre-unlink`: The script MUST be executed before a package is removed / unlinked.
+- `post-unlink`: Deprecated. The script MAY be executed after a package is removed / unlinked.
 
 These scripts should be avoided whenever possible. If they are indeed necessary, these rules apply:
 
@@ -269,6 +269,16 @@ These scripts should be avoided whenever possible. If they are indeed necessary,
 - They MUST NOT touch anything other than the files being installed.
 - They MUST NOT depend on any installed or to-be-installed conda packages.
 - They SHOULD depend only on standard system tools. For example, `rm`, `cp`, `mv`, and `ln` on Unix machines. Or `del`, `ren`, `copy`, and `mklink` on Windows machines.
+
+The following environment variables MUST be exposed to the script runtime:
+
+- `ROOT_PREFIX`: Path to the `base` environment where the conda client is installed. Empty otherwise.
+- `PREFIX`: Path to the target environment.
+- `PKG_NAME`: Name of the package that owns the script.
+- `PKG_VERSION`: Version of the package that owns the script.
+- `PKG_BUILDNUM`: Build number of the package that owns the script.
+
+The `PATH` environment variable MUST include the directory where the script is located as its first element.
 
 ### `Menu/*.json` files
 
@@ -282,7 +292,17 @@ The `./conda-meta/` directory is reserved for conda environments and MUST NOT be
 
 ## Rationale
 
+### About deprecated keys or files
+
 Some keys or files have been proposed for formal deprecation because they are not used widely, and as a result were not adapted from `conda-build` to `rattler-build`.
+
+### About arbitrary code execution at install time
+
+`pre-link` and `post-link` scripts have historically allowed arbitrary code execution at install time. That means that packages may require this feature for them to work correctly (e.g. many packages in `bioconda` use them to fetch additional data files at install time).
+
+The initial revision of this CEP specified that conda clients _MAY_ execute them. This was amended in the second revision to specify that `pre-link`, `post-link` and `pre-unlink` _MUST_ be executed. `post-unlink` scripts [were not documented in conda-build](https://github.com/conda/conda-build/blob/59cd559da7011df1674390d89f50b5f179b4842b/docs/source/resources/link-scripts.rst?plain=1#L5) (that note has since disappeared) but [are indeed handled in `conda`](https://github.com/conda/conda/blob/2e2dd79fa7e2b0ae1fb2fae16b615b4106745acf/conda/core/link.py#L1085-L1110).
+
+This revision was submitted to ensure that existing packages continue working without disruption. Future work may revisit such decision to remove code execution at install time for more reproducible installations.
 
 ## References
 
@@ -290,6 +310,10 @@ Some keys or files have been proposed for formal deprecation because they are no
 - <https://rattler.build/latest/package_spec/>
 - <https://github.com/conda/ceps/pull/124#discussion_r2083137907>
 - [`Library/` conventions on Windows](https://github.com/ContinuumIO/anaconda-issues/issues/440)
+
+## Changelog
+
+- 2026-06-11: Require that `pre-link`, `post-link`, `pre-unlink` MUST be executed. Added a corresponding section in Rationale. Detailed runtime conditions for these scripts.
 
 ## Copyright
 

--- a/cep-0034.md
+++ b/cep-0034.md
@@ -6,7 +6,7 @@
 <tr><td> Author(s) </td><td> Jaime Rodríguez-Guerra &lt;jaime.rogue@gmail.com&gt;</td></tr>
 <tr><td> Created </td><td> Sep 27, 2025</td></tr>
 <tr><td> Updated </td><td> Jun 11, 2026</td></tr>
-<tr><td> Discussion </td><td> https://github.com/conda/ceps/pull/133 </td></tr>
+<tr><td> Discussion </td><td> https://github.com/conda/ceps/pull/133, https://github.com/conda/ceps/issues/169, https://github.com/conda/ceps/pull/173 </td></tr>
 <tr><td> Implementation </td><td> N/A </td></tr>
 <tr><td> Requires </td><td> CEP 29, CEP 31, CEP 32, CEP 33 </td></tr>
 </table>

--- a/cep-0034.md
+++ b/cep-0034.md
@@ -273,7 +273,7 @@ These scripts should be avoided whenever possible. If they are indeed necessary,
 The following environment variables MUST be exposed to the script runtime:
 
 - `ROOT_PREFIX`: Path to the `base` environment where the conda client is installed. Empty otherwise.
-- `PREFIX`: Path to the target environment.
+- `PREFIX`, `SOURCE_DIR`: Path to the target environment.
 - `PKG_NAME`: Name of the package that owns the script.
 - `PKG_VERSION`: Version of the package that owns the script.
 - `PKG_BUILDNUM`: Build number of the package that owns the script.
@@ -310,6 +310,7 @@ This revision was submitted to ensure that existing packages continue working wi
 - <https://rattler.build/latest/package_spec/>
 - <https://github.com/conda/ceps/pull/124#discussion_r2083137907>
 - [`Library/` conventions on Windows](https://github.com/ContinuumIO/anaconda-issues/issues/440)
+- [Runtime conditions of link/unlink scripts](https://github.com/conda/conda/blob/2e2dd79fa7e2b0ae1fb2fae16b615b4106745acf/conda/core/link.py#L1613-L1618)
 
 ## Changelog
 


### PR DESCRIPTION
## Checklist for submitter

- [ ] I am submitting a new CEP: [Put your title here](#link-to-markdown-preview-in-branch).
  - [ ] I am using the CEP template by creating a copy `cep-0000.md` named `cep-XXXX.md` in the root level.
- [X] I am submitting modifications to CEP 34. <!-- reflect CEP number here -->
  - [X] The PR title reflects the CEP I'm modifying: `CEP XX: Amend XYZ`.
  - [X] I updated the "Updated" date.
  - [X] I added the link of this PR to the Discussions row.
  - [X] I added or extended the `## Changelog` section right above the final "Copyright" section with an item that uses syntax `YYYY-MM-DD: Brief explanation of changes`.
- [ ] Something else: (add your description here).


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/governance/blob/main/CODE_OF_CONDUCT.md
-->


- Closes https://github.com/conda/ceps/issues/169