### PR TITLE
CEP 44: Use underscore-separated field names

### DIFF
--- a/cep-0044.md
+++ b/cep-0044.md
@@ -9,7 +9,7 @@
   Jaime Rodríguez-Guerra &lt;jaime.rogue@gmail.com&gt;
 </td></tr>
 <tr><td> Created </td><td> Feb 5, 2025</td></tr>
-<tr><td> Updated </td><td> May 14, 2026</td></tr>
+<tr><td> Updated </td><td> Jul 15, 2026</td></tr>
 <tr><td> Discussion </td><td> https://github.com/conda/ceps/pull/111, https://github.com/conda/ceps/pull/165 </td></tr>
 <tr><td> Implementation </td><td> NA </td></tr>
 </table>
@@ -32,11 +32,11 @@ Instead of overloading the repodata documents with more package names (which cau
 
 ## Rationale
 
-The chosen keyword in CEP 29 `MatchSpec`, keywords is `extras` given its popularity in Python packaging. For CEP 34 `info/index.json` records is `extra-depends` to avoid ambiguity with a hypothetical `extra-constraints`.
+The chosen keyword in CEP 29 `MatchSpec`, keywords is `extras` given its popularity in Python packaging. For CEP 34 `info/index.json` records is `extra_depends` to avoid ambiguity with a hypothetical `extra_constraints`.
 
 ## Specification
 
-The `info/index.json` dictionary of each conda artifact MUST allow a new field, `extra-depends`, the value of which MUST be a dictionary that maps the group names (expressed as a string that MUST match the regex `[a-z0-9_.+-]{1,64}`) to a list of `MatchSpec` strings encoding the optional dependencies. Since this is backwards incompatible behavior-wise, the `schema_version` value MUST be bumped to `3`.
+The `info/index.json` dictionary of each conda artifact MUST allow a new field, `extra_depends`, the value of which MUST be a dictionary that maps the group names (expressed as a string that MUST match the regex `[a-z0-9_.+-]{1,64}`) to a list of `MatchSpec` strings encoding the optional dependencies. Since this is backwards incompatible behavior-wise, the `schema_version` value MUST be bumped to `3`.
 
 The `extras` field MUST also be exposed in recipe formats v1 and above, under the `requirements.extras` section (sibling to `build`, `host`, `run`, etc), that renders to the same schema (`dict[str, list[MatchSpec]]`).
 
@@ -44,7 +44,7 @@ This new field must be selectable by `MatchSpec` syntax using the `extras` keywo
 
 ## Examples
 
-A repodata record with `extra-depends`:
+A repodata record with `extra_depends`:
 
 ```js
 {
@@ -56,7 +56,7 @@ A repodata record with `extra-depends`:
       "depends": [
         "main-dependency"
       ]
-      "extra-depends": {
+      "extra_depends": {
         "group-name": [
           "extra-dependency>=2",
           "another-dependency>=1"
@@ -104,4 +104,6 @@ All CEPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdo
 
 ## Changelog
 
-- May 29, 2026: Fixed regex for valid extra group names.
+- 2026-07-15: Changed `extra-depends` to `extras_depends` for consistency with other undescore-separated field names in `index.json`.
+- 2026-05-29: Fixed regex for valid extra group names.
+- 2026-05-14: Accepted.

--- a/cep-0044.md
+++ b/cep-0044.md
@@ -10,7 +10,7 @@
 </td></tr>
 <tr><td> Created </td><td> Feb 5, 2025</td></tr>
 <tr><td> Updated </td><td> Jul 15, 2026</td></tr>
-<tr><td> Discussion </td><td> https://github.com/conda/ceps/pull/111, https://github.com/conda/ceps/pull/165 </td></tr>
+<tr><td> Discussion </td><td> https://github.com/conda/ceps/pull/111, https://github.com/conda/ceps/pull/165, https://github.com/conda/ceps/pull/181 </td></tr>
 <tr><td> Implementation </td><td> NA </td></tr>
 </table>
 


### PR DESCRIPTION
## Checklist for submitter

- [ ] I am submitting a new CEP: [Put your title here](#link-to-markdown-preview-in-branch).
  - [ ] I am using the CEP template by creating a copy `cep-0000.md` named `cep-XXXX.md` in the root level.
- [X] I am submitting modifications to CEP 44. <!-- reflect CEP number here -->
  - [X] The PR title reflects the CEP I'm modifying: `CEP XX: Amend XYZ`.
  - [X] I updated the "Updated" date.
  - [x] I added the link of this PR to the Discussions row.
  - [X] I added or extended the `## Changelog` section right above the final "Copyright" section with an item that uses syntax `YYYY-MM-DD: Brief explanation of changes`.
- [ ] Something else: (add your description here).

Comes from discussion at https://github.com/conda/ceps/pull/146#discussion_r3581468837
