### PR TITLE
CEP 14: permit $schema in v1 recipes

### DIFF
--- a/cep-0014.md
+++ b/cep-0014.md
@@ -5,7 +5,7 @@
 <tr><td> Status </td><td> Accepted</td></tr>
 <tr><td> Author(s) </td><td> Wolf Vollprecht &lt;wolf@prefix.dev&gt;</td></tr>
 <tr><td> Created </td><td> May 23, 2023</td></tr>
-<tr><td> Updated </td><td> Sep 26, 2025</td></tr>
+<tr><td> Updated </td><td> Jul 29, 2026</td></tr>
 <tr><td> Discussion </td><td> https://github.com/conda-incubator/ceps/pull/56 </td></tr>
 <tr><td> Implementation </td><td>https://github.com/prefix-dev/rattler-build</td></tr>
 </table>
@@ -47,6 +47,18 @@ If outputs exist, the top-level keys are 'merged' with the output keys (e.g. for
 
 ## Format
 
+### Schema declaration
+
+To benefit from autocompletion and other JSON Schema-based features in editors and
+third-party YAML tools, we can add a `$schema` URI reference to the recipe.
+
+```yaml
+#        a URL pointing at a JSON file...
+$schema: https://raw.githubusercontent.com/prefix-dev/recipe-format/992602280/schema.json
+#        ... or relative POSIX path
+# $schema: ./custom-recipe-schema.json
+```
+
 ### Schema version
 
 The implicit version of the YAML schema for a recipe is an integer 1.
@@ -57,12 +69,6 @@ The version can be explicitly set by adding a `schema_version` key to the recipe
 ```yaml
 # optional, since implicitly defaults to 1
 schema_version: 1 # integer
-```
-
-To benefit from autocompletion, and other LSP features in editors, we can add a schema URL to the recipe.
-
-```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/73cd2eed94c576213c5f25ab57adf6d8c83e792a/schema.json
 ```
 
 ### Context section
@@ -570,6 +576,10 @@ extra:
 What follows is an example recipe, using the YAML syntax discussed in <https://github.com/conda-incubator/ceps/pull/54>
 
 ```yaml
+$schema: https://raw.githubusercontent.com/prefix-dev/recipe-format/992602280/schema.json
+
+schema_version: 1
+
 context:
   name: xtensor
   version: 0.24.6
@@ -642,6 +652,10 @@ tests:
 Or a multi-output package
 
 ```yaml
+$schema: https://raw.githubusercontent.com/prefix-dev/recipe-format/992602280/schema.json
+
+schema_version: 1
+
 context:
   name: mamba
   libmamba_version: "1.4.2"
@@ -841,3 +855,4 @@ extra:
 
 - September 24, 2025: Removed `about.license_url` as the field exists but is unused in `conda-build`.
 - September 26, 2025: Permits lists of scalars in `context`.
+- July 29, 2026: Permits `$schema`.

--- a/cep-0014.md
+++ b/cep-0014.md
@@ -54,7 +54,7 @@ third-party YAML tools, we can add a `$schema` URI reference to the recipe.
 
 ```yaml
 #        a URL pointing at a JSON file...
-$schema: https://raw.githubusercontent.com/prefix-dev/recipe-format/992602280/schema.json
+$schema: https://raw.githubusercontent.com/prefix-dev/recipe-format/7e9363f2c/schema.json
 #        ... or relative POSIX path
 # $schema: ./custom-recipe-schema.json
 ```
@@ -576,7 +576,7 @@ extra:
 What follows is an example recipe, using the YAML syntax discussed in <https://github.com/conda-incubator/ceps/pull/54>
 
 ```yaml
-$schema: https://raw.githubusercontent.com/prefix-dev/recipe-format/992602280/schema.json
+$schema: https://raw.githubusercontent.com/prefix-dev/recipe-format/7e9363f2c/schema.json
 
 schema_version: 1
 
@@ -652,7 +652,7 @@ tests:
 Or a multi-output package
 
 ```yaml
-$schema: https://raw.githubusercontent.com/prefix-dev/recipe-format/992602280/schema.json
+$schema: https://raw.githubusercontent.com/prefix-dev/recipe-format/7e9363f2c/schema.json
 
 schema_version: 1
 

--- a/cep-0014.md
+++ b/cep-0014.md
@@ -6,7 +6,7 @@
 <tr><td> Author(s) </td><td> Wolf Vollprecht &lt;wolf@prefix.dev&gt;</td></tr>
 <tr><td> Created </td><td> May 23, 2023</td></tr>
 <tr><td> Updated </td><td> Jul 29, 2026</td></tr>
-<tr><td> Discussion </td><td> https://github.com/conda-incubator/ceps/pull/56 </td></tr>
+<tr><td> Discussion </td><td> https://github.com/conda-incubator/ceps/pull/56 <br/> https://github.com/conda/ceps/pull/186 </td></tr>
 <tr><td> Implementation </td><td>https://github.com/prefix-dev/rattler-build</td></tr>
 </table>
 


### PR DESCRIPTION
## Checklist for submitter

- [ ] I am submitting a new CEP: [Put your title here](#link-to-markdown-preview-in-branch).
  - [ ] I am using the CEP template by creating a copy `cep-0000.md` named `cep-XXXX.md` in the root level.
- [x] I am submitting modifications to CEP 14. <!-- reflect CEP number here -->
  - [x] The PR title reflects the CEP I'm modifying: `CEP XX: Amend XYZ`.
  - [x] I updated the "Updated" date.
  - [x] I added the link of this PR to the Discussions row.
  - [x] I added or extended the `## Changelog` section right above the final "Copyright" section with an item that uses syntax `YYYY-MM-DD: Brief explanation of changes`.
- [ ] Something else: (add your description here).

## references
- https://github.com/prefix-dev/recipe-format/pull/82
- https://github.com/prefix-dev/recipe-format/issues/29
- https://github.com/conda-forge/conda-smithy/pull/2617
- https://github.com/prefix-dev/rattler-build/pull/2645